### PR TITLE
test: Add glob param for test files

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -1,8 +1,22 @@
+const globby = require('globby');
+
 process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+let testFilesGlob = process.argv[process.argv.length - 1]; // last argv
+if (!testFilesGlob.includes('**/')) {
+  testFilesGlob = `test/**/${testFilesGlob}`;
+}
+if (!testFilesGlob.endsWith('*.spec.js')) {
+  testFilesGlob = testFilesGlob.endsWith('*') ? `${testFilesGlob}.spec.js` : `${testFilesGlob}*.spec.js`;
+}
+if (globby.sync(testFilesGlob).length === 0) {
+  testFilesGlob = 'test/**/*.spec.js'; // test all files
+}
+console.log(`Testing files matching "${testFilesGlob}"`);
 
 module.exports = function(config) {
   config.set({
-    files: [{ pattern: 'test/**/*.spec.js', watched: true, type: 'module' }],
+    files: [{ pattern: testFilesGlob, watched: true, type: 'module' }],
 
     browsers: ['ChromeHeadless'],
 

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,16 +1,21 @@
-const globby = require('globby');
+const glob = require('glob');
 
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
-let testFilesGlob = process.argv[process.argv.length - 1]; // last argv
-if (!testFilesGlob.includes('**/')) {
-  testFilesGlob = `test/**/${testFilesGlob}`;
-}
-if (!testFilesGlob.endsWith('*.spec.js')) {
-  testFilesGlob = testFilesGlob.endsWith('*') ? `${testFilesGlob}.spec.js` : `${testFilesGlob}*.spec.js`;
-}
-if (globby.sync(testFilesGlob).length === 0) {
-  testFilesGlob = 'test/**/*.spec.js'; // test all files
+let testFilesGlob = 'test/**/*.spec.js';
+const globIndex = process.argv.indexOf('--glob');
+if (globIndex > -1) {
+  testFilesGlob = process.argv[globIndex + 1] || '';
+  if (!testFilesGlob.includes('**/')) {
+    testFilesGlob = `test/**/${testFilesGlob}`;
+  }
+  if (!testFilesGlob.endsWith('*.spec.js')) {
+    testFilesGlob = `${testFilesGlob}*.spec.js`;
+  }
+  if (glob.sync(testFilesGlob).length === 0) {
+    console.log(`No files matching "${testFilesGlob}"`);
+    process.exit();
+  }
 }
 console.log(`Testing files matching "${testFilesGlob}"`);
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest --runInBand --no-cache --config ./jest.config.js",
     "publish": "npm publish --access public",
     "debug": "karma start karma.config.js --browsers Chrome",
+    "debug:firefox": "karma start karma.config.js --browsers Firefox",
     "karma": "karma start karma.config.js --single-run --browsers ChromeHeadless,FirefoxHeadless"
   },
   "files": [


### PR DESCRIPTION
You can run specific test files or folders like this:

yarn debug:firefox --glob promises
yarn karma --glob membrane/