### PR TITLE
Enable Chrome for Karma tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ run_unit_tests: &run_unit_tests
 run_karma_tests: &run_karma_tests
   run:
     name: Run Karma tests
-    command: npx karma start karma.config.js --single-run --browsers FirefoxHeadless
+    command: yarn karma
 
 
 # Jobs definition


### PR DESCRIPTION
@caridy [Chrome tests work on CircleCI](https://app.circleci.com/pipelines/github/salesforce/near-membrane/4/workflows/955894c3-ca9e-4bf4-8189-ec201aae0161/jobs/5/parallel-runs/0/steps/0-107)