### PR TITLE
Istanbul integration

### DIFF
--- a/src/red.ts
+++ b/src/red.ts
@@ -49,6 +49,7 @@ export interface MarshalHooks {
     construct(target: BlueConstructor, argumentsList: ArrayLike<BlueValue>, newTarget?: any): BlueValue;
 }
 
+// istanbul ignore next
 export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: MembraneBroker, hooks: MarshalHooks) {
     const LockerLiveValueMarkerSymbol = Symbol.for('@@lockerLiveValue');
     const { blueMap, distortionMap } = blueEnv;


### PR DESCRIPTION
Add comment to disable istanbul for serialized code

@caridy this is a non-functional change to help @arcadeteddy with Karma test coverage. He tried to add this comment dynamically using a script in locker repo, but the script is failing (see [here](https://app.circleci.com/pipelines/github/salesforce/locker/1740/workflows/4dc02c2f-daff-4582-8c35-71960922cea8/jobs/2669/parallel-runs/0/steps/0-104)) and would be hacky to try to make it work, I think adding this comment here is the right long term solution. The comments are preserved in the npm package.