### PR TITLE
fix(core) Store reference to TypeError constructors

### DIFF
--- a/packages/near-membrane-base/src/blue.ts
+++ b/packages/near-membrane-base/src/blue.ts
@@ -18,6 +18,7 @@ import {
     ReflectPreventExtensions,
     ReflectSet,
     ReflectSetPrototypeOf,
+    TypeErrorCtor,
     emptyArray,
 } from './shared';
 import {
@@ -222,7 +223,7 @@ export function blueProxyFactory(env: MembraneBroker) {
         construct(shadowTarget: BlueShadowTarget, blueArgArray: BlueValue[], blueNewTarget: BlueObject): BlueValue {
             const { target: RedCtor } = this;
             if (blueNewTarget === undefined) {
-                throw new TypeError();
+                throw new TypeErrorCtor();
             }
             const redNewTarget = env.getRedValue(blueNewTarget);
             const redArgArray = getStaticRedArray(blueArgArray);

--- a/packages/near-membrane-base/src/red.ts
+++ b/packages/near-membrane-base/src/red.ts
@@ -57,6 +57,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
 
     const ArrayCtor = Array;
     const ErrorCtor = Error;
+    const TypeErrorCtor = TypeError;
     const emptyArray: [] = [];
     const noop = () => undefined;
 
@@ -353,7 +354,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
     function redProxyConstructTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedValue {
         const { target: BlueCtor } = this;
         if (redNewTarget === undefined) {
-            throw TypeError();
+            throw new TypeErrorCtor();
         }
         let blue;
         try {

--- a/packages/near-membrane-base/src/shared.ts
+++ b/packages/near-membrane-base/src/shared.ts
@@ -15,6 +15,7 @@ const {
 export const ArrayCtor = Array;
 export const ErrorCtor = Error;
 export const SetCtor = Set;
+export const TypeErrorCtor = TypeError;
 export const WeakMapCtor = WeakMap;
 
 export const { isArray: ArrayIsArray } = Array;


### PR DESCRIPTION
I noticed we didn't store references to the `TypeError` constructors, so fixed that.