### PR TITLE
chore: re-enable Safari for async/await test

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:bundlesize": "bundlesize",
     "test": "yarn test:jest; yarn test:karma",
     "test:jest": "jest --runInBand --no-cache --config jest.config.js",
-    "test:karma": "karma start karma.config.js --single-run --browsers ChromeHeadless,FirefoxHeadless",
+    "test:karma": "karma start karma.config.js --single-run --browsers ChromeHeadless,FirefoxHeadless,Safari",
     "version": "yarn build",
     "bump": "lerna version --exact --no-push --yes",
     "bump:patch": "lerna version patch --exact --no-push --yes",

--- a/test/membrane/async-await.spec.js
+++ b/test/membrane/async-await.spec.js
@@ -1,11 +1,7 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 
-// TODO #115 - Skip Firefox and Safari until we find a solution for them
-const isFirefox = navigator.userAgent.includes('Firefox/');
-const isSafari = navigator.userAgent.includes('Safari/');
-const skipTests = isFirefox || isSafari;
-
-if (!skipTests) {
+// TODO #115 - Skip Firefox ~~and Safari~~ until we find a solution for them
+if (!navigator.userAgent.includes('Firefox/')) {
     describe("async/await", () => {
         it("basic wrapping", (done) => {
             const evalScript = createVirtualEnvironment({ endowments: { done, expect }});

--- a/test/membrane/async-await.spec.js
+++ b/test/membrane/async-await.spec.js
@@ -1,6 +1,6 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 
-// TODO #115 - Skip Firefox ~~and Safari~~ until we find a solution for them
+// TODO #115 - Skip Firefox until we find a non-compiler based solution for them
 if (!navigator.userAgent.includes('Firefox/')) {
     describe("async/await", () => {
         it("basic wrapping", (done) => {


### PR DESCRIPTION
This is pending SauceLabs update to support Safari 14.1