### PR TITLE
test: @W-9323615@ near-membrane-base/src/shared.ts to 100% coverage

### DIFF
--- a/packages/near-membrane-base/src/__tests__/shared.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/shared.spec.ts
@@ -1,0 +1,65 @@
+import { ObjectLookupOwnGetter, WeakMapHas } from '../shared';
+
+describe('ObjectLookupOwnGetter', () => {
+    it('should return undefined when object argument is null', () => {
+        expect.assertions(1);
+        expect(ObjectLookupOwnGetter(null)).toBe(undefined);
+    });
+    it('should return undefined when object argument is undefined', () => {
+        expect.assertions(1);
+        expect(ObjectLookupOwnGetter(undefined)).toBe(undefined);
+    });
+    it('should return undefined when object argument has no such property', () => {
+        expect.assertions(1);
+        expect(ObjectLookupOwnGetter({}, 'foo')).toBe(undefined);
+    });
+    it('should return getter when object argument has property and getter', () => {
+        expect.assertions(1);
+        const o = {
+            get x() {
+                return 1;
+            },
+        };
+        expect(ObjectLookupOwnGetter(o, 'x')).toBe(Object.getOwnPropertyDescriptor(o, 'x').get);
+    });
+    it('should not lookup inherited getters', () => {
+        expect.assertions(2);
+
+        class C {
+            get foo() {
+                return this;
+            }
+        }
+
+        const c = new C();
+
+        const o = Object.create({
+            get foo() {
+                return this;
+            },
+        });
+
+        expect(ObjectLookupOwnGetter(c, 'foo')).toBe(undefined);
+        expect(ObjectLookupOwnGetter(o, 'foo')).toBe(undefined);
+    });
+});
+
+describe('WeakMapHas', () => {
+    const key = {};
+    const value = {};
+    const map = new Map([[key, value]]);
+    const weakMap = new WeakMap([[key, value]]);
+
+    it('should not work with a non-WeakMap', () => {
+        expect.assertions(1);
+
+        expect(() => {
+            WeakMapHas(map, key);
+        }).toThrow(TypeError);
+    });
+
+    it('should work with a WeakMap', () => {
+        expect.assertions(1);
+        expect(WeakMapHas(weakMap, key)).toBe(true);
+    });
+});


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/27985/121749144-2e17f200-cad8-11eb-9a47-e93d4fa48ed7.png)


After: 
![image](https://user-images.githubusercontent.com/27985/121749160-33753c80-cad8-11eb-9d8f-638369e67d3d.png)


The tests here reach the parts that aren't being indirectly reached by other tests. 

Eventually, I'd like to have full "standalone" coverage for all of these modules. 