### PR TITLE
feat: make coverage script more user friendly and remove dead code

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint packages test",
     "prepare": "husky install && yarn build",
     "start": "http-server ./examples",
-    "coverage": "yarn coverage:jest; yarn coverage:karma",
+    "coverage": "yarn coverage:jest && yarn coverage:karma && yarn coverage:merge && yarn coverage:report",
     "coverage:jest": "yarn test:jest --coverage",
     "coverage:karma": "yarn test:karma --coverage",
     "coverage:merge": "istanbul-merge --out coverage-merged.json coverage/coverage-final.json coverage/json/coverage.json",

--- a/packages/near-membrane-base/src/__tests__/shared.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/shared.spec.ts
@@ -43,23 +43,3 @@ describe('ObjectLookupOwnGetter', () => {
         expect(ObjectLookupOwnGetter(o, 'foo')).toBe(undefined);
     });
 });
-
-describe('WeakMapHas', () => {
-    const key = {};
-    const value = {};
-    const map = new Map([[key, value]]);
-    const weakMap = new WeakMap([[key, value]]);
-
-    it('should not work with a non-WeakMap', () => {
-        expect.assertions(1);
-
-        expect(() => {
-            WeakMapHas(map, key);
-        }).toThrow(TypeError);
-    });
-
-    it('should work with a WeakMap', () => {
-        expect.assertions(1);
-        expect(WeakMapHas(weakMap, key)).toBe(true);
-    });
-});

--- a/packages/near-membrane-base/src/shared.ts
+++ b/packages/near-membrane-base/src/shared.ts
@@ -63,14 +63,10 @@ export function SetHas(set: Set<any>, key: any): boolean {
 export const TypeErrorCtor = TypeError;
 
 export const WeakMapCtor = WeakMap;
-const { get: WeakMapProtoGet, has: WeakMapProtoHas, set: WeakMapProtoSet } = WeakMap.prototype;
+const { get: WeakMapProtoGet, set: WeakMapProtoSet } = WeakMap.prototype;
 
 export function WeakMapGet(map: WeakMap<object, object>, key: object): object | undefined {
     return ReflectApply(WeakMapProtoGet, map, [key]);
-}
-
-export function WeakMapHas(map: WeakMap<object, object>, key: object): boolean {
-    return ReflectApply(WeakMapProtoHas, map, [key]);
 }
 
 export function WeakMapSet(


### PR DESCRIPTION
As part of the QA for code coverage of near-membrane-base I ran into a rough spot making sure I was seeing the right numbers, so made the script easier and then found some dead code (as my numbers reported are ~96%).