### PR TITLE
feat: expand call stack limit for red realm

### DIFF
--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -1,4 +1,5 @@
 import {
+    ObjectHasOwnProperty,
     ReflectGetOwnPropertyDescriptor,
     ReflectOwnKeys,
     SetCtor,
@@ -190,4 +191,15 @@ export function getFilteredEndowmentDescriptors(endowments: object): PropertyDes
 
 export function isIntrinsicGlobalName(key: PropertyKey): boolean {
     return SetHas(ESGlobalKeys, key);
+}
+
+export function setupStackTrace(global: typeof globalThis) {
+    const { Error } = global;
+    if (
+        ObjectHasOwnProperty(Error, 'stackTraceLimit') &&
+        typeof Error.stackTraceLimit === 'number'
+    ) {
+        // The default stack trace limit is 10. Increasing to 20 as a baby step.
+        Error.stackTraceLimit *= 2;
+    }
 }

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -6,6 +6,7 @@ import {
     emptyArray,
     linkIntrinsics,
     getFilteredEndowmentDescriptors,
+    setupStackTrace,
 } from '@locker/near-membrane-base';
 
 import { getCachedBlueReferences, getRedReferences, linkUnforgeables, tameDOM } from './window';
@@ -96,6 +97,7 @@ export default function createVirtualEnvironment(
         redGlobalThis: redWindow,
         distortionCallback,
     });
+    setupStackTrace(redWindow);
     linkIntrinsics(env, blueWindow, redWindow);
     linkUnforgeables(env, blueRefs, redRefs);
     tameDOM(env, blueRefs, redRefs, endowmentsDescriptors);

--- a/packages/near-membrane-node/src/node-realm.ts
+++ b/packages/near-membrane-node/src/node-realm.ts
@@ -3,6 +3,7 @@ import {
     EnvironmentOptions,
     getFilteredEndowmentDescriptors,
     linkIntrinsics,
+    setupStackTrace,
 } from '@locker/near-membrane-base';
 
 import { runInNewContext } from 'vm';
@@ -28,6 +29,7 @@ export default function createVirtualEnvironment(
         redGlobalThis,
         distortionCallback,
     });
+    setupStackTrace(redGlobalThis);
     linkIntrinsics(env, blueGlobalThis, redGlobalThis);
 
     // remapping globals


### PR DESCRIPTION
This is the beginning of work to eventually clean up stack traces. We'll need to transform method names in order to detect and filter them. But that's next release.