### PR TITLE
refactor: moving closer to add callable boundary support (step 1)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -88,7 +88,8 @@
         "no-unsafe-finally": "warn",
         "no-param-reassign": "off",
         "@typescript-eslint/no-shadow": "warn",
-        "no-shadow": "warn"
+        "no-shadow": "warn",
+        "no-bitwise": "off"
       }
     }
   ]

--- a/packages/near-membrane-base/src/blue.ts
+++ b/packages/near-membrane-base/src/blue.ts
@@ -20,6 +20,7 @@ import {
     ReflectSet,
     ReflectSetPrototypeOf,
     TypeErrorCtor,
+    WeakMapGet,
 } from './shared';
 import {
     BlueArray,
@@ -170,7 +171,7 @@ export function blueProxyFactory(env: MembraneBroker) {
 
     function getBlueFunction(redFn: RedFunction): BlueFunction {
         // caching logic
-        const blueFn = env.getBlueRef(redFn);
+        const blueFn = WeakMapGet(env.redMap, redFn) as RedFunction | undefined;
         if (blueFn !== undefined) {
             return blueFn;
         }
@@ -207,7 +208,7 @@ export function blueProxyFactory(env: MembraneBroker) {
 
     function getBlueObjectOrArray(red: RedArrayOrObject): BlueArrayOrObject {
         // caching logic
-        const blue = env.getBlueRef(red);
+        const blue: RedArrayOrObject | undefined = WeakMapGet(env.redMap, red);
         if (blue !== undefined) {
             return blue;
         }

--- a/packages/near-membrane-base/src/blue.ts
+++ b/packages/near-membrane-base/src/blue.ts
@@ -44,6 +44,7 @@ const { isArray: isArrayOrNotOrThrowForRevoked } = Array;
 
 // eslint-disable-next-line no-shadow
 enum TargetTraits {
+    None = 0,
     IsArray = 1 << 0,
     IsFunction = 1 << 1,
     IsObject = 1 << 2,
@@ -178,7 +179,7 @@ export function blueProxyFactory(env: MembraneBroker) {
         let targetFunctionName: string | undefined;
         // detecting arrow function vs function
         try {
-            targetTraits |= (!('prototype' in redFn) ? 1 : 0) << 3; // IsArrowFunction
+            targetTraits |= +!('prototype' in redFn) && TargetTraits.IsArrowFunction;
         } catch {
             // target is either a revoked proxy, or a proxy that throws on the
             // `has` trap, in which case going with a strict mode function seems
@@ -203,7 +204,7 @@ export function blueProxyFactory(env: MembraneBroker) {
             return blue;
         }
         // extracting the metadata about the proxy target
-        let targetTraits = 0;
+        let targetTraits = TargetTraits.None;
         const targetFunctionName = undefined;
         let targetIsArray = false;
         try {
@@ -213,8 +214,8 @@ export function blueProxyFactory(env: MembraneBroker) {
             // target is a revoked proxy, so the type doesn't matter much from this point on
         }
 
-        targetTraits |= (targetIsArray ? 1 : 0) << 0; // IsArray
-        targetTraits |= (targetIsArray ? 0 : 1) << 2; // IsObject
+        targetTraits |= +targetIsArray && TargetTraits.IsArray;
+        targetTraits |= +!targetIsArray && TargetTraits.IsObject;
 
         return (createBlueProxy(
             (red as unknown) as BlueProxyTarget,

--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -9,7 +9,6 @@ import {
     ReflectOwnKeys,
     RegExpTest,
     WeakMapCtor,
-    WeakMapGet,
     WeakMapSet,
 } from './shared';
 import { MarshalHooks, serializedRedEnvSourceText } from './red';
@@ -103,32 +102,6 @@ export class VirtualEnvironment implements MembraneBroker {
         blue: BlueValue
     ): RedValue {
         // placeholder since this will be assigned in construction
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    getBlueRef(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        red: RedValue
-    ): BlueValue | undefined {
-        const blue: RedValue | undefined = WeakMapGet(this.redMap, red);
-        if (blue !== undefined) {
-            return blue;
-        }
-        // Explicit to satisfy the consistent-return elint rule
-        return undefined;
-    }
-
-    // Currently, getRedRef is not used in any near-membrane-* modules,
-    // nor is used by any modules that directly depend on near-membrane.
-    // istanbul ignore next
-    // eslint-disable-next-line class-methods-use-this
-    getRedRef(blue: BlueValue): RedValue | undefined {
-        const red: RedValue | undefined = WeakMapGet(this.blueMap, blue);
-        if (red !== undefined) {
-            return red;
-        }
-        // Explicit to satisfy the consistent-return elint rule
-        return undefined;
     }
 
     setRefMapEntries(red: RedObject, blue: BlueObject) {

--- a/packages/near-membrane-base/src/red.ts
+++ b/packages/near-membrane-base/src/red.ts
@@ -115,6 +115,7 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
 
     // eslint-disable-next-line no-shadow
     enum TargetTraits {
+        None = 0,
         IsArray = 1 << 0,
         IsFunction = 1 << 1,
         IsObject = 1 << 2,
@@ -254,7 +255,7 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
         let targetFunctionName: string | undefined;
         // detecting arrow function vs function
         try {
-            targetTraits |= (!('prototype' in blueOriginalOrDistortedValue) ? 1 : 0) << 3; // IsArrowFunction
+            targetTraits |= +!('prototype' in blueOriginalOrDistortedValue) && TargetTraits.IsArrowFunction;
         } catch {
             // target is either a revoked proxy, or a proxy that throws on the
             // `has` trap, in which case going with a strict mode function seems
@@ -284,7 +285,7 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
             return red;
         }
         // extracting the metadata about the proxy target
-        let targetTraits = 0;
+        let targetTraits = TargetTraits.None;
         const targetFunctionName = undefined;
         let targetIsArray = false;
         try {
@@ -294,8 +295,8 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
             // target is a revoked proxy, so the type doesn't matter much from this point on
         }
 
-        targetTraits |= (targetIsArray ? 1 : 0) << 0; // IsArray
-        targetTraits |= (targetIsArray ? 0 : 1) << 2; // IsObject
+        targetTraits |= +targetIsArray && TargetTraits.IsArray;
+        targetTraits |= +!targetIsArray && TargetTraits.IsObject;
 
         return (createRedProxy(
             blueOriginalOrDistortedValue,

--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -59,5 +59,3 @@ export interface TargetMeta extends NullProtoMap {
     isExtensible?: boolean;
     isBroken?: boolean;
 }
-
-export type ProxyTargetType = 'object' | 'function';

--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -6,6 +6,7 @@ export type BlueProxyTarget = RedObject | RedFunction | RedConstructor;
 // TODO: how to doc the ProxyOf<>
 export type BlueShadowTarget = BlueProxyTarget; // Proxy<BlueProxyTarget>;
 export type BlueValue = any;
+export type BlueArrayOrObject = BlueArray | BlueObject;
 
 export interface BlueConstructor {
     new (...args: any[]): BlueObject;
@@ -46,6 +47,7 @@ export type RedProxy = RedObject | RedFunction;
 export type RedProxyTarget = BlueObject | BlueFunction | BlueConstructor;
 export type RedShadowTarget = RedProxyTarget; // Proxy<RedProxyTarget>;
 export type RedValue = any;
+export type RedArrayOrObject = RedArray | RedObject;
 
 export interface RedConstructor {
     new (...args: any[]): RedObject;
@@ -59,3 +61,5 @@ export interface TargetMeta extends NullProtoMap {
     isExtensible?: boolean;
     isBroken?: boolean;
 }
+
+export type ProxyTargetType = 'object' | 'function';

--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -26,8 +26,6 @@ export interface MembraneBroker {
 
     getBlueValue(red: RedValue): BlueValue;
     getRedValue(blue: BlueValue): RedValue;
-    getBlueRef(red: RedValue): BlueValue | undefined;
-    getRedRef(blue: BlueValue): RedValue | undefined;
     setRefMapEntries(red: RedValue, blue: BlueValue): void;
 }
 


### PR DESCRIPTION
The main objective here is to introduce the concept of the shape of the remote proxy when creating those proxies rather than doing direct inspection of the target when creating the proxy because in a callable boundary scenario, you will never have access to the actual target.