### PR TITLE
fix: avoid object spread inside the serialized redEnvFactory

### DIFF
--- a/packages/near-membrane-base/src/red.ts
+++ b/packages/near-membrane-base/src/red.ts
@@ -78,6 +78,7 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
     const { isArray: isArrayOrNotOrThrowForRevoked } = Array;
 
     const {
+        assign: ObjectAssign,
         defineProperties: ObjectDefineProperties,
         getOwnPropertyDescriptors: ObjectGetOwnPropertyDescriptors,
         freeze: ObjectFreeze,
@@ -194,6 +195,8 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
     }
 
     function getBluePartialDescriptor(redPartialDesc: PropertyDescriptor): PropertyDescriptor {
+        // We cannot use object spread inside the serialized redEnvFactory
+        // function because it will be missing the _objectSpread Babel helper.
         const bluePartialDesc = { __proto__: null, ...redPartialDesc };
         if ('writable' in bluePartialDesc) {
             // We are dealing with a value descriptor.
@@ -226,6 +229,8 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
     }
 
     function getRedDescriptor(blueDescriptor: PropertyDescriptor): PropertyDescriptor {
+        // We cannot use object spread inside the serialized redEnvFactory
+        // function because it will be missing the _objectSpread Babel helper.
         const redDescriptor = { __proto__: null, ...blueDescriptor };
         if ('writable' in redDescriptor) {
             // We are dealing with a value descriptor.

--- a/packages/near-membrane-base/src/red.ts
+++ b/packages/near-membrane-base/src/red.ts
@@ -197,7 +197,8 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
     function getBluePartialDescriptor(redPartialDesc: PropertyDescriptor): PropertyDescriptor {
         // We cannot use object spread inside the serialized redEnvFactory
         // function because it will be missing the _objectSpread Babel helper.
-        const bluePartialDesc = { __proto__: null, ...redPartialDesc };
+        // eslint-disable-next-line prefer-object-spread
+        const bluePartialDesc = ObjectAssign({ __proto__: null }, redPartialDesc);
         if ('writable' in bluePartialDesc) {
             // We are dealing with a value descriptor.
             bluePartialDesc.value = blueEnv.getBlueValue(bluePartialDesc.value);
@@ -231,7 +232,8 @@ export const serializedRedEnvSourceText = /* prettier-ignore */ (function redEnv
     function getRedDescriptor(blueDescriptor: PropertyDescriptor): PropertyDescriptor {
         // We cannot use object spread inside the serialized redEnvFactory
         // function because it will be missing the _objectSpread Babel helper.
-        const redDescriptor = { __proto__: null, ...blueDescriptor };
+        // eslint-disable-next-line prefer-object-spread
+        const redDescriptor = ObjectAssign({ __proto__: null }, blueDescriptor);
         if ('writable' in redDescriptor) {
             // We are dealing with a value descriptor.
             redDescriptor.value = getRedValue(redDescriptor.value);


### PR DESCRIPTION
This is coming in for a patch release:

Avoid object spread inside the serialized `redEnvFactory`.
This will be taken care of in the future with the callable boundary PR (#178)