### PR TITLE
fix: guard against globals that may not yet exist in a given runtime

### DIFF
--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -1125,6 +1125,9 @@ export function init(
         // this mapping return a pointer for each of the reflective intrinsics
         // and their respective prototype so both sides of the membrane can link them out.
         const reflectiveValue = globalThis[globalName];
+        if (!reflectiveValue) {
+            return;
+        }
         const reflectivePointer = createPointer(reflectiveValue);
         reflectiveValues.push(reflectiveValue);
         reflectivePointers.push(reflectivePointer);


### PR DESCRIPTION
Previously, when processing the `ReflectIntrinsicObjectNames`, near-membrane-base was guarding against the possibility of one of the names not existing in the runtime, ie. `AggregateError` (https://github.com/salesforce/near-membrane/blob/33938f60a514d5e72d84d309a5cb42c5fba24ee2/packages/near-membrane-base/src/intrinsics.ts#L151-L171). This restores that protection. 