### PR TITLE
feat: avoid object spread, use loops instead of `Array#map` in hot path, etc.

### DIFF
--- a/packages/near-membrane-base/package.json
+++ b/packages/near-membrane-base/package.json
@@ -5,6 +5,7 @@
     "author": "Caridy Patiño <caridy@gmail.com>",
     "description": "JavaScript Near Membrane Library to create a sandboxed environment",
     "main": "lib/index.js",
+    "sideEffects": false,
     "type": "module",
     "types": "types/index.d.ts",
     "scripts": {

--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -27,9 +27,10 @@ interface VirtualEnvironmentOptions {
 const undefinedSymbol = Symbol('membrane@undefined');
 const { test: RegExpProtoTest } = RegExp.prototype;
 const ErrorCtor = Error;
-const { keys: ObjectKeys, propertyIsEnumerable: ObjectPropertyIsEnumerable } = Object;
+const { assign: ObjectAssign, keys: ObjectKeys } = Object;
+const { propertyIsEnumerable: ObjectProtoPropertyIsEnumerable } = Object.prototype;
 const { apply: ReflectApply, ownKeys: ReflectOwnKeys } = Reflect;
-const { includes: ArrayIncludes, push: ArrayPush } = Array.prototype;
+const { includes: ArrayProtoIncludes, push: ArrayProtoPush } = Array.prototype;
 
 function RegExpTest(regexp: RegExp, str: string): boolean {
     return ReflectApply(RegExpProtoTest, regexp, [str]);
@@ -138,8 +139,8 @@ export class VirtualEnvironment {
                 continue;
             }
             // Avoid poisoning by only installing own properties from blueDescriptors
-            // @ts-ignore
-            const blueDescriptor = { __proto__: null, ...blueDescriptors[key] };
+            // eslint-disable-next-line prefer-object-spread
+            const blueDescriptor = ObjectAssign({ __proto__: null }, (blueDescriptors as any)[key]);
             const configurable =
                 'configurable' in blueDescriptor ? !!blueDescriptor.configurable : undefinedSymbol;
             const enumerable =
@@ -187,10 +188,10 @@ export class VirtualEnvironment {
             }
             const isEnumerable =
                 typeof key === 'symbol'
-                    ? ReflectApply(ObjectPropertyIsEnumerable, o, [key])
-                    : ReflectApply(ArrayIncludes, enumerablePropertyKeys, [key]);
+                    ? ReflectApply(ObjectProtoPropertyIsEnumerable, o, [key])
+                    : ReflectApply(ArrayProtoIncludes, enumerablePropertyKeys, [key]);
 
-            ReflectApply(ArrayPush, args, [key, isEnumerable]);
+            ReflectApply(ArrayProtoPush, args, [key, isEnumerable]);
         }
         ReflectApply(this.redCallableInstallLazyDescriptors, undefined, args);
     }

--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -5,10 +5,6 @@ const {
     ownKeys: ReflectOwnKeys,
 } = Reflect;
 
-function SetHas(set: Set<any>, key: any): boolean {
-    return ReflectApply(SetProtoHas, set, [key]);
-}
-
 /**
  * This list must be in sync with ecma-262, anything new added to the global object
  * should be considered, to decide whether or not they need remapping. The default
@@ -116,7 +112,7 @@ export function getFilteredEndowmentDescriptors(endowments: object): PropertyDes
         // will be ignored if present in the endowments object.
         // TODO: what if the intent is to polyfill one of those
         // intrinsics?
-        if (!SetHas(ESGlobalKeys, key)) {
+        if (!ReflectApply(SetProtoHas, ESGlobalKeys, [key])) {
             to[key] = ReflectGetOwnPropertyDescriptor(endowments, key)!;
         }
     }
@@ -124,5 +120,5 @@ export function getFilteredEndowmentDescriptors(endowments: object): PropertyDes
 }
 
 export function isIntrinsicGlobalName(key: PropertyKey): boolean {
-    return SetHas(ESGlobalKeys, key);
+    return ReflectApply(SetProtoHas, ESGlobalKeys, [key]);
 }

--- a/packages/near-membrane-dom/package.json
+++ b/packages/near-membrane-dom/package.json
@@ -5,6 +5,7 @@
     "author": "Caridy Patiño <caridy@gmail.com>",
     "description": "JavaScript DOM Membrane Library to create a sandboxed environment in the browser",
     "main": "lib/index.js",
+    "sideEffects": false,
     "type": "module",
     "types": "types/index.d.ts",
     "scripts": {

--- a/packages/near-membrane-node/package.json
+++ b/packages/near-membrane-node/package.json
@@ -5,6 +5,7 @@
     "author": "Caridy Patiño <caridy@gmail.com>",
     "description": "JavaScript Node Membrane Library to create a sandboxed environment in Node",
     "main": "lib/index.js",
+    "sideEffects": false,
     "type": "module",
     "types": "types/index.d.ts",
     "scripts": {


### PR DESCRIPTION
### Cleanup
 * Avoid object spread (avoid transpiling with Babel helpers for Edge Legacy)
 * Use loops instead of `Array#map` in hot path
 * Consistent naming
 * `"sideEffects": false` (for non-rollup bundlers within Salesforce)