### PR TITLE
refactor: moving the reflection logic out of VirtualEnvironment

### DIFF
--- a/packages/near-membrane-base/src/__tests__/environment.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/environment.spec.ts
@@ -36,6 +36,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const redValue = {};
             const endowments = {
@@ -61,6 +62,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const redValue = {} as any;
             Object.defineProperty(redValue, 'a', {
@@ -100,6 +102,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
 
@@ -135,6 +138,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
             Object.defineProperty(endowments, 'c', {
@@ -179,6 +183,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const redValue = {};
             const endowments = {
@@ -204,6 +209,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const redValue = {};
             const endowments = {
@@ -232,6 +238,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const redValue = {} as any;
             Object.defineProperty(redValue, 'd', {
@@ -267,6 +274,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
 
@@ -308,6 +316,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
 
@@ -347,6 +356,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
             Object.defineProperty(endowments, 'g', {
@@ -391,6 +401,7 @@ describe('VirtualEnvironment', () => {
                     return v;
                 },
             });
+            ve.link('globalThis');
 
             const endowments = {};
             Object.defineProperty(endowments, 'h', {

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -4,9 +4,10 @@ import {
     initSourceTextInStrictMode,
     ProxyTarget,
     VirtualEnvironment,
+    linkIntrinsics,
 } from '@locker/near-membrane-base';
 
-import { getCachedBlueReferences, getRedReferences, tameDOM } from './window';
+import { getCachedBlueReferences, getRedReferences, linkUnforgeables, tameDOM } from './window';
 
 interface EnvironmentOptions {
     distortionCallback?: (originalTarget: ProxyTarget) => ProxyTarget;
@@ -125,6 +126,9 @@ export default function createVirtualEnvironment(
         redConnector,
         distortionCallback,
     });
+    env.link('window');
+    linkIntrinsics(env, blueWindow);
+    linkUnforgeables(env, blueWindow);
     tameDOM(env, blueRefs, redRefs, endowmentsDescriptors);
     // once we get the iframe info ready, and all mapped, we can proceed
     // to detach the iframe only if the keepAlive option isn't true

--- a/packages/near-membrane-dom/src/index.ts
+++ b/packages/near-membrane-dom/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './browser-realm';
+export { VirtualEnvironment } from '@locker/near-membrane-base';

--- a/packages/near-membrane-dom/src/window.ts
+++ b/packages/near-membrane-dom/src/window.ts
@@ -238,3 +238,22 @@ export function tameDOM(
     env.remap(blueRefs.WindowPropertiesProto, WindowPropertiesDescriptors);
     env.remap(blueRefs.WindowProto, blueRefs.WindowProtoDescriptors);
 }
+
+export function linkUnforgeables(
+    env: VirtualEnvironment,
+    blueGlobalThis: Window & typeof globalThis
+) {
+    // The test of instance of event target is important to discard environments in which
+    // a fake window (e.g. jest) is not following the specs, and can break this
+    // membrane.
+    if (blueGlobalThis.EventTarget && blueGlobalThis instanceof EventTarget) {
+        // window.document
+        env.link(`document`);
+        // window.__proto__ (aka Window.prototype)
+        env.link(`__proto__`);
+        // window.__proto__.__proto__ (aka WindowProperties.prototype)
+        env.link(`__proto__.__proto__`);
+        // window.__proto__.__proto__.__proto__ (aka EventTarget.prototype)
+        env.link(`__proto__.__proto__.__proto__`);
+    }
+}

--- a/packages/near-membrane-node/src/node-realm.ts
+++ b/packages/near-membrane-node/src/node-realm.ts
@@ -4,6 +4,7 @@ import {
     initSourceTextInStrictMode,
     ProxyTarget,
     VirtualEnvironment,
+    linkIntrinsics,
 } from '@locker/near-membrane-base';
 
 import { runInNewContext } from 'vm';
@@ -31,6 +32,8 @@ export default function createVirtualEnvironment(
         redConnector,
         distortionCallback,
     });
+    env.link('globalThis');
+    linkIntrinsics(env, blueGlobalThis);
 
     // remapping globals
     env.remap(blueGlobalThis, endowmentsDescriptors);


### PR DESCRIPTION
This is the step 1 toward support for multi-window/multi-doc in locker. This PR will allow a distortion to create a virtual environment to connect an iframe with an existing virtual environment.