### PR TITLE
refactor: using list instead of string split for path

### DIFF
--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -159,8 +159,7 @@ export class VirtualEnvironment {
         }
     }
 
-    link(path: string) {
-        const keys = path.split('.');
+    link(...keys: PropertyKey[]) {
         let bluePointer = this.blueGlobalThisPointer;
         let redPointer = this.redGlobalThisPointer;
         for (let i = 0, len = keys.length; i < len; i += 1) {

--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -129,7 +129,7 @@ export function linkIntrinsics(env: VirtualEnvironment, blueGlobalThis: typeof g
             const reflectiveValueProto = reflectiveValue.prototype;
             // Proxy.prototype is undefined, being the only weird thing here
             if (reflectiveValueProto) {
-                env.link(`${globalName}.prototype`);
+                env.link(globalName, `prototype`);
             }
         }
     }

--- a/packages/near-membrane-dom/src/window.ts
+++ b/packages/near-membrane-dom/src/window.ts
@@ -252,8 +252,8 @@ export function linkUnforgeables(
         // window.__proto__ (aka Window.prototype)
         env.link(`__proto__`);
         // window.__proto__.__proto__ (aka WindowProperties.prototype)
-        env.link(`__proto__.__proto__`);
+        env.link(`__proto__`, `__proto__`);
         // window.__proto__.__proto__.__proto__ (aka EventTarget.prototype)
-        env.link(`__proto__.__proto__.__proto__`);
+        env.link(`__proto__`, `__proto__`, `__proto__`);
     }
 }


### PR DESCRIPTION
Based on the following discussion: https://github.com/salesforce/near-membrane/pull/192#issuecomment-926938701