### PR TITLE
feat: move and reshape Locker agnostic instrumentation interface to n…

### DIFF
--- a/packages/near-membrane-base/src/index.ts
+++ b/packages/near-membrane-base/src/index.ts
@@ -1,3 +1,4 @@
 export * from './membrane';
 export * from './environment';
 export * from './intrinsics';
+export * from './instrumentation';

--- a/packages/near-membrane-base/src/instrumentation.ts
+++ b/packages/near-membrane-base/src/instrumentation.ts
@@ -1,0 +1,12 @@
+export type InstrumentationDataType = object | string | number | boolean;
+
+export interface InstrumentationHooks {
+    startActivity(activityName: string, data?: InstrumentationDataType): Activity;
+    log(data: InstrumentationDataType): void;
+    error(data: InstrumentationDataType): void;
+}
+
+export interface Activity {
+    stop(data?: InstrumentationDataType): void;
+    error(data?: InstrumentationDataType): void;
+}

--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -257,8 +257,9 @@ export function init(
                 const activity = instrumentation.startActivity(activityName, { crossingDirection });
                 try {
                     result = ReflectApply(fn, this, args);
-                } catch (ex) {
-                    activity.error(ex as any);
+                } catch (e: any) {
+                    activity.error(e);
+                    throw e;
                 } finally {
                     activity.stop();
                 }

--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -246,6 +246,7 @@ export function init(
     // to the callable functions used to coordinate work between the sides
     // of the membrane.
     // TODO: do we need to pass more info into instrumentation hooks?
+    // prettier-ignore
     function instrumentCallableWrapper<T extends (...args: any[]) => any>(
         fn: T,
         activityName: string,

--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -255,16 +255,10 @@ export function init(
             return <T>function instrumentedFn(this: any, ...args: any[]): any {
                 let result;
                 const activity = instrumentation.startActivity(activityName, { crossingDirection });
-                let error: Error;
                 try {
                     result = ReflectApply(fn, this, args);
                 } catch (ex) {
-                    if (ex instanceof Error) {
-                        error = ex;
-                    } else {
-                        error = new Error(`Unkown type of catch variable: ${ex}`);
-                    }
-                    activity.error(error);
+                    activity.error(ex as any);
                 } finally {
                     activity.stop();
                 }


### PR DESCRIPTION
Adding the reshaped agnostic instrumentation interface to near-membrane package. Both Locker project and Near-membrane project uses the instrumentation interface. Locker project depends on Near-membrane. Therefore, near-membrane package is the best home for the interface without making a new repository/package for it.