### PR TITLE
fix: eval can't be shared across the boundary, instead it gets linked

### DIFF
--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -117,6 +117,7 @@ const ReflectiveIntrinsicObjectNames = [
     'SyntaxError',
     'TypeError',
     'URIError',
+    'eval',
 ];
 
 export function linkIntrinsics(env: VirtualEnvironment, blueGlobalThis: typeof globalThis) {


### PR DESCRIPTION
This change protects against accidentally leaking `eval` from one to side another. If you pass `eval` as an argument, or return `eval` in a function invoked from the other side, the eval will be remapped to the local eval, meaning no leaking capabilities to evaluate code.