### PR TITLE
feat: support membrane symbols

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "node": true
   },
   "globals": {
-    "globalThis": false
+    "BigInt": "readonly",
+    "globalThis": "readonly"
   },
   "parserOptions": {
     "ecmaVersion": 2020,

--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -30,9 +30,11 @@ interface VirtualEnvironmentOptions {
     instrumentation?: InstrumentationHooks;
 }
 
+const LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL = Symbol.for(
+    '@@lockerNearMembraneUndefinedValue'
+);
 const SHOULD_TRAP_MUTATION = true;
 const SHOULD_NOT_TRAP_MUTATION = false;
-const UNDEFINED_SYMBOL = Symbol.for('@@membraneUndefinedValue');
 
 const ErrorCtor = Error;
 const { assign: ObjectAssign, keys: ObjectKeys } = Object;
@@ -211,22 +213,22 @@ export class VirtualEnvironment {
                 ownKey,
                 'configurable' in safeBlueDesc
                     ? !!safeBlueDesc.configurable
-                    : UNDEFINED_SYMBOL,
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL,
                 'enumerable' in safeBlueDesc
                     ? !!safeBlueDesc.enumerable
-                    : UNDEFINED_SYMBOL,
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL,
                 'writable' in safeBlueDesc
                     ? !!safeBlueDesc.writable
-                    : UNDEFINED_SYMBOL,
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL,
                 'value' in safeBlueDesc
                     ? this.blueGetTransferableValue(safeBlueDesc.value)
-                    : UNDEFINED_SYMBOL,
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL,
                 'get' in safeBlueDesc
                     ? this.blueGetTransferableValue(safeBlueDesc.get) as Pointer
-                    : UNDEFINED_SYMBOL,
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL,
                 'set' in safeBlueDesc
                     ? this.blueGetTransferableValue(safeBlueDesc.set) as Pointer
-                    : UNDEFINED_SYMBOL
+                    : LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL
             );
         }
     }

--- a/test/dom/membrane-symbols.spec.js
+++ b/test/dom/membrane-symbols.spec.js
@@ -1,0 +1,515 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for(
+    '@@lockerNearMembraneSerializedValue'
+);
+const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');
+
+function freezeObject(object, inheritFrom = Reflect.getPrototypeOf(object)) {
+    const frozenProto = Object.create(inheritFrom);
+    Object.freeze(frozenProto);
+    Reflect.setPrototypeOf(object, frozenProto);
+    Object.freeze(object);
+    return object;
+}
+
+describe('@@lockerNearMembrane', () => {
+    it('should be detectable', () => {
+        expect.assertions(12);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in insideValue).toBe(false);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(true);
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');
+
+            exposeTakeInside(function takeInside(outsideValue) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in outsideValue).toBe(false);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(undefined);
+            });
+        `);
+
+        // Test red proxies.
+        takeInside({ outsideObject: 1 });
+        takeInside(Object.create(null, { outsideObjectWithNullProto: { value: 1 } }));
+        takeInside(['outsideArray']);
+
+        env.evaluate(`
+            // Test blue proxies.
+            takeOutside({ insideObject: 1 });
+            takeOutside(Object.create(null, { insideObjectWithNullProto: { value: 1 } }));
+            takeOutside(['insideArray']);
+        `);
+    });
+
+    it('should not be detectable when customized', () => {
+        expect.assertions(12);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue, expectedSymbolValue) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in insideValue).toBe(true);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(expectedSymbolValue);
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');
+
+            exposeTakeInside(function takeInside(outsideValue, expectedSymbolValue) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in outsideValue).toBe(true);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(expectedSymbolValue);
+            });
+        `);
+
+        // Test red proxies.
+        const outsideObjectSymbolValue = 'outsideObject';
+        const outsideObject = { [LOCKER_NEAR_MEMBRANE_SYMBOL]: outsideObjectSymbolValue };
+        takeInside(outsideObject, outsideObjectSymbolValue);
+
+        const outsideObjectWithNullProtoSymbolValue = 'outsideObjectWithNullProto';
+        const outsideObjectWithNullProto = Object.create(null, {
+            [LOCKER_NEAR_MEMBRANE_SYMBOL]: { value: outsideObjectWithNullProtoSymbolValue },
+        });
+        takeInside(outsideObjectWithNullProto, outsideObjectWithNullProtoSymbolValue);
+
+        const outsideArraySymbolValue = 'outsideArray';
+        const outsideArray = [];
+        outsideArray[LOCKER_NEAR_MEMBRANE_SYMBOL] = outsideArraySymbolValue;
+        takeInside(outsideArray, outsideArraySymbolValue);
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');
+
+            // Test blue proxies.
+            const insideObjectSymbolValue = 'insideObject';
+            const insideObject = { [LOCKER_NEAR_MEMBRANE_SYMBOL]: insideObjectSymbolValue };
+            takeOutside(insideObject, insideObjectSymbolValue);
+
+            const insideObjectWithNullProtoSymbolValue = 'insideObjectWithNullProto';
+            const insideObjectWithNullProto = Object.create(null, {
+                [LOCKER_NEAR_MEMBRANE_SYMBOL]: { value: insideObjectWithNullProtoSymbolValue },
+            });
+            takeOutside(insideObjectWithNullProto, insideObjectWithNullProtoSymbolValue);
+
+            const insideArraySymbolValue = 'insideArray';
+            const insideArray = [];
+            insideArray[LOCKER_NEAR_MEMBRANE_SYMBOL] = insideArraySymbolValue;
+            takeOutside(insideArray, insideArraySymbolValue);
+        `);
+    });
+
+    it('should not throw proxy invariant violation errors', () => {
+        expect.assertions(12);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in insideValue).toBe(false);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(true);
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');
+
+            exposeTakeInside(function takeInside(outsideValue) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SYMBOL in outsideValue).toBe(false);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SYMBOL]).toBe(undefined);
+            });
+        `);
+
+        // Test red proxies.
+        takeInside(freezeObject({ outsideFrozenObject: 1 }));
+        takeInside(freezeObject({ outsideFrozenObjectWithNullProto: 1 }, null));
+        takeInside(freezeObject(['outsideFrozenArray']));
+
+        env.evaluate(`
+            function freezeObject(object, inheritFrom = Reflect.getPrototypeOf(object)) {
+                const frozenProto = Object.create(inheritFrom);
+                Object.freeze(frozenProto);
+                Reflect.setPrototypeOf(object, frozenProto);
+                Object.freeze(object);
+                return object;
+            }
+
+            // Test blue proxies.
+            takeOutside(freezeObject({ insideFrozenObject: 1 }));
+            takeOutside(freezeObject({ insideFrozenObjectWithNullProto: 1 }, null));
+            takeOutside(freezeObject(['insideFrozenArray']));
+        `);
+    });
+});
+
+describe('@@lockerNearMembraneSerializedValue', () => {
+    it('should be detectable', () => {
+        expect.assertions(36);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue, expectedSerialized) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in insideValue).toBe(false);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSerialized
+                );
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for(
+                '@@lockerNearMembraneSerializedValue'
+            );
+
+            exposeTakeInside(function takeInside(outsideValue, expectedSerialized) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in outsideValue).toBe(false);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSerialized
+                );
+            });
+        `);
+
+        // Test red proxies.
+        takeInside(Object(BigInt(0x1fffffffffffff)), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(new Boolean(true), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(new Boolean(false), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(new Number(0), undefined);
+        // prettier-ignore
+        takeInside(/outsideRegExpLiteral/img, undefined);
+        // eslint-disable-next-line prefer-regex-literals
+        takeInside(new RegExp('outsideRegExpObject', 'img'), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(new String('outsideString'), undefined);
+        const symbol = Symbol('outsideSymbol');
+        takeInside(Object(symbol), undefined);
+        takeInside(['outsideArray'], undefined);
+
+        env.evaluate(`
+            // Test blue proxies.
+            takeOutside(Object(BigInt(0x1fffffffffffff)), BigInt(0x1fffffffffffff));
+            takeOutside(new Boolean(true), true);
+            takeOutside(new Boolean(false), false);
+            takeOutside(new Number(0), 0);
+            takeOutside(
+                /insideRegExpLiteral/ysu,
+                JSON.stringify({
+                    flags: 'suy',
+                    source: 'insideRegExpLiteral',
+                })
+            );
+            takeOutside(
+                new RegExp('insideRegExpObject', 'ysu'),
+                JSON.stringify({
+                    flags: 'suy',
+                    source: 'insideRegExpObject',
+                })
+            );
+            takeOutside(new String('insideString'), 'insideString');
+            const symbol = Symbol('insideSymbol');
+            takeOutside(Object(symbol), symbol);
+            takeOutside(['insideArray'], undefined);
+        `);
+    });
+
+    it('should not be detectable when customized', () => {
+        expect.assertions(36);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue, expectedSymbolValue) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in insideValue).toBe(true);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSymbolValue
+                );
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for(
+                '@@lockerNearMembraneSerializedValue'
+            );
+
+            exposeTakeInside(function takeInside(outsideValue, expectedSymbolValue) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in outsideValue).toBe(true);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSymbolValue
+                );
+            });
+        `);
+        // Test blue proxies.
+        const outsideBigIntObjectSymbolValue = 'outsideBigIntObject';
+        const outsideBigIntObject = Object(BigInt(0x1fffffffffffff));
+        outsideBigIntObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideBigIntObjectSymbolValue;
+        takeInside(outsideBigIntObject, outsideBigIntObjectSymbolValue);
+
+        const outsideBooleanTrueObjectSymbolValue = 'outsideBooleanTrueObject';
+        // eslint-disable-next-line no-new-wrappers
+        const outsideBooleanTrueObject = new Boolean(true);
+        outsideBooleanTrueObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideBooleanTrueObjectSymbolValue;
+        takeInside(outsideBooleanTrueObject, outsideBooleanTrueObjectSymbolValue);
+
+        const outsideBooleanFalseObjectSymbolValue = 'outsideBooleanFalseObject';
+        // eslint-disable-next-line no-new-wrappers
+        const outsideBooleanFalseObject = new Boolean(true);
+        outsideBooleanFalseObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideBooleanFalseObjectSymbolValue;
+        takeInside(outsideBooleanFalseObject, outsideBooleanFalseObjectSymbolValue);
+
+        const outsideNumberObjectSymbolValue = 'outsideNumberObject';
+        // eslint-disable-next-line no-new-wrappers
+        const outsideNumberObject = new Number(0);
+        outsideNumberObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideNumberObjectSymbolValue;
+        takeInside(outsideNumberObject, outsideNumberObjectSymbolValue);
+        const outsideRegExpLiteralSymbolValue = 'outsideRegExpLiteral';
+
+        // prettier-ignore
+        const outsideRegExpLiteral = /outsideRegExpLiteral/img;
+        outsideRegExpLiteral[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideRegExpLiteralSymbolValue;
+        takeInside(outsideRegExpLiteral, outsideRegExpLiteralSymbolValue);
+
+        const outsideRegExpObjectSymbolValue = 'outsideRegExpObject';
+        // eslint-disable-next-line prefer-regex-literals
+        const outsideRegExpObject = new RegExp('outsideRegExpObject', 'img');
+        outsideRegExpObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideRegExpObjectSymbolValue;
+        takeInside(outsideRegExpObject, outsideRegExpObjectSymbolValue);
+
+        const outsideStringObjectSymbolValue = 'outsideStringObject';
+        // eslint-disable-next-line no-new-wrappers
+        const outsideStringObject = new String('outsideString');
+        outsideStringObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideStringObjectSymbolValue;
+        takeInside(outsideStringObject, outsideStringObjectSymbolValue);
+
+        const outsideSymbolObjectSymbolValue = 'outsideSymbolObject';
+        // eslint-disable-next-line no-new-wrappers
+        const outsideSymbolObject = Object(Symbol('outsideSymbol'));
+        outsideSymbolObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+            outsideSymbolObjectSymbolValue;
+        takeInside(outsideSymbolObject, outsideSymbolObjectSymbolValue);
+
+        const outsideArraySymbolValue = 'outsideArray';
+        const outsideArray = ['outsideArray'];
+        outsideArray[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] = outsideArraySymbolValue;
+        takeInside(outsideArray, outsideArraySymbolValue);
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for(
+                '@@lockerNearMembraneSerializedValue'
+            );
+
+            // Test blue proxies.
+            const insideBigIntObjectSymbolValue = 'insideBigIntObject';
+            const insideBigIntObject = Object(BigInt(0x1fffffffffffff));
+            insideBigIntObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideBigIntObjectSymbolValue;
+            takeOutside(insideBigIntObject, insideBigIntObjectSymbolValue);
+
+            const insideBooleanTrueObjectSymbolValue = 'insideBooleanTrueObject';
+            // eslint-disable-next-line no-new-wrappers
+            const insideBooleanTrueObject = new Boolean(true);
+            insideBooleanTrueObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideBooleanTrueObjectSymbolValue;
+            takeOutside(insideBooleanTrueObject, insideBooleanTrueObjectSymbolValue);
+
+            const insideBooleanFalseObjectSymbolValue = 'insideBooleanFalseObject';
+            // eslint-disable-next-line no-new-wrappers
+            const insideBooleanFalseObject = new Boolean(true);
+            insideBooleanFalseObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideBooleanFalseObjectSymbolValue;
+            takeOutside(insideBooleanFalseObject, insideBooleanFalseObjectSymbolValue);
+
+            const insideNumberObjectSymbolValue = 'insideNumberObject';
+            // eslint-disable-next-line no-new-wrappers
+            const insideNumberObject = new Number(0);
+            insideNumberObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideNumberObjectSymbolValue;
+            takeOutside(insideNumberObject, insideNumberObjectSymbolValue);
+
+            const insideRegExpLiteralSymbolValue = 'insideRegExpLiteral';
+            const insideRegExpLiteral = /insideRegExpLiteral/suy;
+            insideRegExpLiteral[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideRegExpLiteralSymbolValue;
+            takeOutside(insideRegExpLiteral, insideRegExpLiteralSymbolValue);
+
+            const insideRegExpObjectSymbolValue = 'insideRegExpObject';
+            const insideRegExpObject = new RegExp('insideRegExpObject', 'suy');
+            insideRegExpObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideRegExpObjectSymbolValue;
+            takeOutside(insideRegExpObject, insideRegExpObjectSymbolValue);
+
+            const insideStringObjectSymbolValue = 'insideStringObject';
+            // eslint-disable-next-line no-new-wrappers
+            const insideStringObject = new String('insideString');
+            insideStringObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideStringObjectSymbolValue;
+            takeOutside(insideStringObject, insideStringObjectSymbolValue);
+
+            const insideSymbolObjectSymbolValue = 'insideSymbolObject';
+            // eslint-disable-next-line no-new-wrappers
+            const insideSymbolObject = Object(Symbol('insideSymbol'));
+            insideSymbolObject[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] =
+                insideSymbolObjectSymbolValue;
+            takeOutside(insideSymbolObject, insideSymbolObjectSymbolValue);
+
+            const insideArraySymbolValue = 'insideArray';
+            const insideArray = ['insideArray'];
+            insideArray[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] = insideArraySymbolValue;
+            takeOutside(insideArray, insideArraySymbolValue);
+        `);
+    });
+
+    it('should not throw proxy invariant violation errors', () => {
+        expect.assertions(36);
+
+        // eslint-disable-next-line no-unused-vars
+        let takeInside;
+
+        const endowments = {
+            expect,
+            exposeTakeInside(func) {
+                takeInside = func;
+            },
+            takeOutside(insideValue, expectedSerialized) {
+                // Test blue proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in insideValue).toBe(false);
+                expect(insideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSerialized
+                );
+            },
+        };
+
+        const env = createVirtualEnvironment(window, window, { endowments });
+
+        env.evaluate(`
+            const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for(
+                '@@lockerNearMembraneSerializedValue'
+            );
+
+            exposeTakeInside(function takeInside(outsideValue, expectedSerialized) {
+                // Test red proxies.
+                expect(LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in outsideValue).toBe(false);
+                expect(outsideValue[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL]).toBe(
+                    expectedSerialized
+                );
+            });
+        `);
+
+        // Test red proxies.
+        takeInside(freezeObject(Object(BigInt(0x1fffffffffffff))), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(freezeObject(new Boolean(true)), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(freezeObject(new Boolean(false)), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(freezeObject(new Number(0)), undefined);
+        // prettier-ignore
+        takeInside(freezeObject(/outsideFrozenRegExpLiteral/img), undefined);
+        // eslint-disable-next-line prefer-regex-literals
+        takeInside(new RegExp('outsideFrozenRegExpObject', 'img'), undefined);
+        // eslint-disable-next-line no-new-wrappers
+        takeInside(freezeObject(new String('outsideFrozenStringObject')), undefined);
+        takeInside(freezeObject(Object(Symbol('outsideFrozenSymbolObject'))), undefined);
+        takeInside(freezeObject(['outsideFrozenArray']), undefined);
+
+        env.evaluate(`
+            function freezeObject(object, inheritFrom = Reflect.getPrototypeOf(object)) {
+                const frozenProto = Object.create(inheritFrom);
+                Object.freeze(frozenProto);
+                Reflect.setPrototypeOf(object, frozenProto);
+                Object.freeze(object);
+                return object;
+            }
+
+            // Test blue proxies.
+            takeOutside(
+                freezeObject(Object(BigInt(0x1fffffffffffff))),
+                BigInt(0x1fffffffffffff)
+            );
+            takeOutside(freezeObject(new Boolean(true)), true);
+            takeOutside(freezeObject(new Boolean(false)), false);
+            takeOutside(freezeObject(new Number(0)), 0);
+            takeOutside(
+                freezeObject(/insideFrozenRegExpLiteral/ysu),
+                JSON.stringify({
+                    flags: 'suy',
+                    source: 'insideFrozenRegExpLiteral',
+                })
+            );
+            takeOutside(
+                freezeObject(
+                    new RegExp('insideFrozenRegExpObject', 'ysu')
+                ),
+                JSON.stringify({
+                    flags: 'suy',
+                    source: 'insideFrozenRegExpObject',
+                })
+            );
+            takeOutside(freezeObject(new String('insideFrozenString')), 'insideFrozenString');
+            const symbol = Symbol('insideFrozenSymbol');
+            takeOutside(freezeObject(Object(symbol)), symbol);
+            takeOutside(freezeObject(['insideFrozenArray']), undefined);
+        `);
+    });
+});

--- a/test/membrane/object-branding.spec.js
+++ b/test/membrane/object-branding.spec.js
@@ -1,31 +1,35 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 
 describe('object-branding', () => {
-    it('should respect branding of target', () => {
+    it('should get branding of target', () => {
+        expect.assertions(28);
+
         const env = createVirtualEnvironment(window, window, {
             endowments: { expect },
         });
         env.evaluate(`
-            const { toString: ObjectProtoToString } = Object.prototype;
-
             function getToStringTag(object) {
-                return ObjectProtoToString.call(object).slice(8, -1);
+                return Object.prototype.toString.call(object).slice(8, -1);
             }
 
             expect(getToStringTag([])).toBe('Array');
-            expect(getToStringTag(new Boolean())).toBe('Boolean');
+            expect(getToStringTag(new Array())).toBe('Array');
+            expect(getToStringTag(new Boolean(true))).toBe('Boolean');
             expect(getToStringTag(function (){})).toBe('Function');
             expect(getToStringTag(async ()=>{})).toBe('AsyncFunction');
             expect(getToStringTag(function * (){})).toBe('GeneratorFunction');
             expect(getToStringTag(async function * (){})).toBe('AsyncGeneratorFunction');
             expect(getToStringTag(new Date())).toBe('Date');
             expect(getToStringTag({})).toEqual('Object');
-            expect(getToStringTag(new Number(1))).toBe('Number');
+            expect(getToStringTag(new Number(0))).toBe('Number');
             expect(getToStringTag(/a/)).toBe('RegExp');
-            expect(getToStringTag(new String('Hello!'))).toBe('String');
+            expect(getToStringTag(new RegExp('a'))).toBe('RegExp');
+            expect(getToStringTag(new String('a'))).toBe('String');
+            expect(getToStringTag(Object(Symbol('a')))).toBe('Symbol');
 
             const buffer = new ArrayBuffer(8);
             expect(getToStringTag(buffer)).toBe('ArrayBuffer');
+            expect(getToStringTag(new DataView(buffer))).toBe('DataView');
             expect(getToStringTag(new Float32Array(buffer))).toBe('Float32Array');
             expect(getToStringTag(new Float64Array(buffer))).toBe('Float64Array');
             expect(getToStringTag(new Int8Array(buffer))).toBe('Int8Array');
@@ -37,6 +41,63 @@ describe('object-branding', () => {
             expect(getToStringTag(new Uint32Array(buffer))).toBe('Uint32Array');
 
             const custom = { [Symbol.toStringTag]: 'Custom' };
+            expect(getToStringTag(custom)).toBe('Custom');
+
+            const inheritedCustom = Object.create(custom);
+            expect(getToStringTag(inheritedCustom)).toBe('Custom');
+
+            const overwrittenCustom = Object.create(custom, {
+                [Symbol.toStringTag]: { value: 'Overwritten' },
+            });
+            expect(getToStringTag(overwrittenCustom)).toBe('Overwritten');
+        `);
+    });
+
+    it('should get branding of with targets with null prototypes', () => {
+        expect.assertions(28);
+
+        const env = createVirtualEnvironment(window, window, {
+            endowments: { expect },
+        });
+        env.evaluate(`
+            function getToStringTag(object) {
+                return Object.prototype.toString.call(object).slice(8, -1);
+            }
+
+            function nullProto(object) {
+                Reflect.setPrototypeOf(object, null);
+                return object;
+            }
+
+            expect(getToStringTag(nullProto([]))).toBe('Array');
+            expect(getToStringTag(nullProto(new Array()))).toBe('Array');
+            expect(getToStringTag(nullProto(new Boolean(true)))).toBe('Boolean');
+            expect(getToStringTag(nullProto(function (){}))).toBe('Function');
+            expect(getToStringTag(nullProto(async ()=>{}))).toBe('Function');
+            expect(getToStringTag(nullProto(function * (){}))).toBe('Function');
+            expect(getToStringTag(nullProto(async function * (){}))).toBe('Function');
+            expect(getToStringTag(nullProto(new Date()))).toBe('Date');
+            expect(getToStringTag(nullProto({}))).toEqual('Object');
+            expect(getToStringTag(nullProto(new Number(0)))).toBe('Number');
+            expect(getToStringTag(nullProto(/a/))).toBe('RegExp');
+            expect(getToStringTag(nullProto(new RegExp('a')))).toBe('RegExp');
+            expect(getToStringTag(nullProto(new String('a')))).toBe('String');
+            expect(getToStringTag(nullProto(Object(Symbol('a'))))).toBe('Object');
+
+            const buffer = new ArrayBuffer(8);
+            expect(getToStringTag(nullProto(buffer))).toBe('ArrayBuffer');
+            expect(getToStringTag(nullProto(new DataView(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Float32Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Float64Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Int8Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Int16Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Int32Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Uint8Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Uint8ClampedArray(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Uint16Array(buffer)))).toBe('Object');
+            expect(getToStringTag(nullProto(new Uint32Array(buffer)))).toBe('Object');
+
+            const custom = nullProto({ [Symbol.toStringTag]: 'Custom' });
             expect(getToStringTag(custom)).toBe('Custom');
 
             const inheritedCustom = Object.create(custom);

--- a/test/membrane/symbols.spec.js
+++ b/test/membrane/symbols.spec.js
@@ -1,13 +1,9 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 
-// eslint-disable-next-line symbol-description
-globalThis.regularSymbol = Symbol();
-globalThis.symbolWithDescription = Symbol('symbol-with-desc');
-globalThis.symbolWithKey = Symbol.for('symbol-with-key');
-
-describe('Secure Membrane', () => {
+describe('Symbols', () => {
     it('should support symbols', () => {
         expect.assertions(6);
+
         const env = createVirtualEnvironment(window, window);
         env.evaluate(`
             expect(typeof Symbol() === 'symbol').toBeTrue();
@@ -20,23 +16,36 @@ describe('Secure Membrane', () => {
     });
     it('should allow access to symbols defined in outer realm', () => {
         expect.assertions(3);
+
+        // eslint-disable-next-line symbol-description
+        globalThis.regularSymbol = Symbol();
+        globalThis.symbolWithDescription = Symbol('symbol-with-desc');
+        globalThis.symbolWithKey = Symbol.for('symbol-with-key');
         const env = createVirtualEnvironment(window, window);
         env.evaluate(`
             expect(typeof globalThis.regularSymbol).toBe('symbol');
             expect(typeof globalThis.symbolWithDescription).toBe('symbol');
             expect(typeof globalThis.symbolWithKey).toBe('symbol');
         `);
+        delete globalThis.regularSymbol;
+        delete globalThis.symbolWithDescription;
+        delete globalThis.symbolWithKey;
     });
     it('should not leak outer realm global reference via symbols', () => {
         expect.assertions(2);
+
+        // eslint-disable-next-line symbol-description
+        globalThis.regularSymbol = Symbol();
         const env = createVirtualEnvironment(window, window);
         env.evaluate(`
             expect(globalThis.regularSymbol.constructor).toBe(Symbol);
             expect(globalThis.regularSymbol.constructor.__proto__.constructor('return this')() === globalThis).toBeTrue();
         `);
+        delete globalThis.regularSymbol;
     });
     it('should not leak outer realm global reference via Symbol.for()', () => {
         expect.assertions(3);
+
         const env = createVirtualEnvironment(window, window);
         env.evaluate(`
             expect(typeof Symbol.for('symbol-with-key')).toBe('symbol');
@@ -46,7 +55,7 @@ describe('Secure Membrane', () => {
     });
 
     it('blue Symbol class properties are inherited in red environments', () => {
-        const symbol = Symbol.for('method');
+        const symbol = Symbol('method');
 
         let successful = false;
 


### PR DESCRIPTION
feat: support membrane symbols

This is the ground-work for structured clone support https://github.com/salesforce/locker/pull/617
by adding support for 2 new membrane symbols:

- `Symbol.for('@@lockerNearMembrane')`
- `Symbol.for('@@lockerNearMembraneSerializedValue')`

These symbols act as if they don't exist but when access will return a value
```js
const LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL = Symbol.for('@@lockerNearMembraneSerializedValue');
const LOCKER_NEAR_MEMBRANE_SYMBOL = Symbol.for('@@lockerNearMembrane');

LOCKER_NEAR_MEMBRANE_SYMBOL in myMembraneProxiedObject // => false
LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL in myMembraneProxiedObject // => false
```
However on an unshadowed accessed:
```js
myMembraneProxiedObject[LOCKER_NEAR_MEMBRANE_SYMBOL] // => true
myMembraneProxiedRegExp[LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL] // => '{"flags":...,"source":...}'
```
