### PR TITLE
feat: add array buffer and regexp to live objects, no longer memoize toStringTags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,8 @@
   },
   "globals": {
     "BigInt": "readonly",
+    "BigInt64Array": "readonly",
+    "BigUint64Array": "readonly",
     "globalThis": "readonly"
   },
   "parserOptions": {

--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -148,14 +148,15 @@ export class VirtualEnvironment {
             // 8: redCallableConstruct,
             9: redCallableDefineProperty,
             // 10: redCallableDeleteProperty,
-            // 11: redCallableGetOwnPropertyDescriptor,
-            // 12: redCallableGetPrototypeOf,
-            // 13: redCallableHas,
-            // 14: redCallableIsExtensible,
-            // 15: redCallableOwnKeys,
-            // 16: redCallablePreventExtensions,
-            // 17: redCallableSet,
-            18: redCallableSetPrototypeOf,
+            // 11: redCallableGet,
+            // 12: redCallableGetOwnPropertyDescriptor,
+            // 13: redCallableGetPrototypeOf,
+            // 14: redCallableHas,
+            // 15: redCallableIsExtensible,
+            // 16: redCallableOwnKeys,
+            // 17: redCallablePreventExtensions,
+            // 18: redCallableSet,
+            19: redCallableSetPrototypeOf,
         } = redHooks!;
         this.redGlobalThisPointer = redGlobalThisPointer;
         this.redCallableEvaluate = redCallableEvaluate;

--- a/packages/near-membrane-node/src/__tests__/freezing.spec.js
+++ b/packages/near-membrane-node/src/__tests__/freezing.spec.js
@@ -63,7 +63,7 @@ describe('Freezing', () => {
                 expect({ ...exoticObject }).toEqual({ x: 1, y: 2, z: 3 });
             `);
             // Verify the sandboxed expando doesn't leak to blue exoticObject.
-            expect(globalThis.exoticObject).toEqual(new ExoticObject({ x: 1 }));
+            expect({ ...globalThis.exoticObject }).toEqual({ x: 1 });
             delete globalThis.exoticObject;
         });
         it('should be observed from within the sandbox after mutation of plain objects', () => {

--- a/test/membrane/expandos.spec.js
+++ b/test/membrane/expandos.spec.js
@@ -20,7 +20,7 @@ describe('The membrane', () => {
             expect({ ...exoticObject }).toEqual({ x: 1, y: 2 });
         `);
         expect(window.plainObject).toEqual({ x: 1, y: 2 });
-        expect(window.exoticObject).toEqual(new ExoticObject({ x: 1 }));
+        expect({ ...window.exoticObject }).toEqual({ x: 1 });
         env.evaluate(`
             // Still be 2 during another evaluation.
             expect(plainObject).toEqual({ x: 1, y: 2 });

--- a/test/membrane/freezing.spec.js
+++ b/test/membrane/freezing.spec.js
@@ -139,7 +139,7 @@ describe('Freezing', () => {
                 expect({ ...exoticObject }).toEqual({ x: 1, y: 2, z: 3 });
             `);
             // Verify the sandboxed expando doesn't leak to blue exoticObject.
-            expect(window.exoticObject).toEqual(new ExoticObject({ x: 1 }));
+            expect({ ...window.exoticObject }).toEqual({ x: 1 });
             delete window.exoticObject;
         });
         it('should be observed from within the sandbox after mutation of plain objects', () => {

--- a/test/membrane/life-red-proxies.spec.js
+++ b/test/membrane/life-red-proxies.spec.js
@@ -8,7 +8,28 @@ class ExoticObject {
     }
 }
 
+const array = [];
+const buffer = new ArrayBuffer(8);
+const bigInt64Array = new BigInt64Array(buffer);
+const bigUint64Array = new BigUint64Array(buffer);
+const dataView = new DataView(buffer);
+const float32Array = new Float32Array(buffer);
+const float64Array = new Float64Array(buffer);
+const int8Array = new Int8Array(buffer);
+const int16Array = new Int16Array(buffer);
+const int32Array = new Int32Array(buffer);
+const uint8Array = new Uint8Array(buffer);
+const regexp = /a/;
+const uint8ClampedArray = new Uint8ClampedArray(buffer);
+const uint16Array = new Uint16Array(buffer);
+const uint32Array = new Uint32Array(buffer);
+
 const plainObject = {
+    x: 'uno',
+};
+
+const plainObjectNullProto = {
+    __proto__: null,
     x: 'uno',
 };
 
@@ -17,68 +38,391 @@ Reflect.defineProperty(exoticLiveObject, LOCKER_LIVE_VALUE_MARKER_SYMBOL, {});
 
 const env = createVirtualEnvironment(window, window, {
     endowments: {
+        array,
+        bigInt64Array,
+        bigUint64Array,
+        buffer,
+        dataView,
         exoticLiveObject,
         expect,
+        float32Array,
+        float64Array,
+        int8Array,
+        int16Array,
+        int32Array,
         jasmine,
         plainObject,
+        plainObjectNullProto,
+        regexp,
+        uint8Array,
+        uint8ClampedArray,
+        uint16Array,
+        uint32Array,
     },
 });
 
 describe('a live red proxy', () => {
     it('should surface new expandos from blue realm', () => {
-        expect.assertions(2);
+        expect.assertions(18);
 
         exoticLiveObject.x = 'uno';
         exoticLiveObject.y = 'dos';
+
         plainObject.x = 'uno';
         plainObject.y = 'dos';
+
+        plainObjectNullProto.x = 'uno';
+        plainObjectNullProto.y = 'dos';
+
+        array.x = 'uno';
+        array.y = 'dos';
+
+        bigInt64Array.x = 'uno';
+        bigInt64Array.y = 'dos';
+
+        bigUint64Array.x = 'uno';
+        bigUint64Array.y = 'dos';
+
+        buffer.x = 'uno';
+        buffer.y = 'dos';
+
+        dataView.x = 'uno';
+        dataView.y = 'dos';
+
+        float32Array.x = 'uno';
+        float32Array.y = 'dos';
+
+        float64Array.x = 'uno';
+        float64Array.y = 'dos';
+
+        int8Array.x = 'uno';
+        int8Array.y = 'dos';
+
+        int16Array.x = 'uno';
+        int16Array.y = 'dos';
+
+        int32Array.x = 'uno';
+        int32Array.y = 'dos';
+
+        regexp.x = 'uno';
+        regexp.y = 'dos';
+
+        uint8Array.x = 'uno';
+        uint8Array.y = 'dos';
+
+        uint8ClampedArray.x = 'uno';
+        uint8ClampedArray.y = 'dos';
+
+        uint16Array.x = 'uno';
+        uint16Array.y = 'dos';
+
+        uint32Array.x = 'uno';
+        uint32Array.y = 'dos';
+
         env.evaluate(`
-            expect(exoticLiveObject).toEqual(jasmine.objectContaining({ x: 'uno', y: 'dos' }));
-            expect(plainObject).toEqual(jasmine.objectContaining({ x: 'uno', y: 'dos' }));
+            const equalMatcher = jasmine.objectContaining({
+                x: 'uno',
+                y: 'dos',
+            });
+
+            expect(exoticLiveObject).toEqual(equalMatcher);
+            expect(plainObject).toEqual(equalMatcher);
+            expect(plainObjectNullProto).toEqual(equalMatcher);
+            expect(array).toEqual(equalMatcher);
+            expect(bigInt64Array).toEqual(equalMatcher);
+            expect(bigUint64Array).toEqual(equalMatcher);
+            expect(buffer).toEqual(equalMatcher);
+            expect(dataView).toEqual(equalMatcher);
+            expect(float32Array).toEqual(equalMatcher);
+            expect(float64Array).toEqual(equalMatcher);
+            expect(int8Array).toEqual(equalMatcher);
+            expect(int16Array).toEqual(equalMatcher);
+            expect(int32Array).toEqual(equalMatcher);
+            expect(regexp).toEqual(equalMatcher);
+            expect(uint8Array).toEqual(equalMatcher);
+            expect(uint8ClampedArray).toEqual(equalMatcher);
+            expect(uint16Array).toEqual(equalMatcher);
+            expect(uint32Array).toEqual(equalMatcher);
         `);
     });
     it('should allow mutation from blue realm', () => {
-        expect.assertions(4);
+        expect.assertions(36);
 
         exoticLiveObject.x = 'tres';
         exoticLiveObject.y = 'cuatro';
+
         plainObject.x = 'tres';
         plainObject.y = 'cuatro';
-        env.evaluate(`
-            expect(exoticLiveObject).toEqual(jasmine.objectContaining({ x: 'tres', y: 'cuatro' }));
-            expect(plainObject).toEqual(jasmine.objectContaining({ x: 'tres', y: 'cuatro' }));
-        `);
-        expect(exoticLiveObject).toEqual(jasmine.objectContaining({ x: 'tres', y: 'cuatro' }));
-        expect(plainObject).toEqual(jasmine.objectContaining({ x: 'tres', y: 'cuatro' }));
-    });
-    it('should allow mutation from within the sandbox', () => {
-        expect.assertions(4);
+
+        plainObjectNullProto.x = 'tres';
+        plainObjectNullProto.y = 'cuatro';
+
+        array.x = 'tres';
+        array.y = 'cuatro';
+
+        bigInt64Array.x = 'tres';
+        bigInt64Array.y = 'cuatro';
+
+        bigUint64Array.x = 'tres';
+        bigUint64Array.y = 'cuatro';
+
+        buffer.x = 'tres';
+        buffer.y = 'cuatro';
+
+        dataView.x = 'tres';
+        dataView.y = 'cuatro';
+
+        float32Array.x = 'tres';
+        float32Array.y = 'cuatro';
+
+        float64Array.x = 'tres';
+        float64Array.y = 'cuatro';
+
+        int8Array.x = 'tres';
+        int8Array.y = 'cuatro';
+
+        int16Array.x = 'tres';
+        int16Array.y = 'cuatro';
+
+        int32Array.x = 'tres';
+        int32Array.y = 'cuatro';
+
+        regexp.x = 'tres';
+        regexp.y = 'cuatro';
+
+        uint8Array.x = 'tres';
+        uint8Array.y = 'cuatro';
+
+        uint8ClampedArray.x = 'tres';
+        uint8ClampedArray.y = 'cuatro';
+
+        uint16Array.x = 'tres';
+        uint16Array.y = 'cuatro';
+
+        uint32Array.x = 'tres';
+        uint32Array.y = 'cuatro';
 
         env.evaluate(`
+            const equalMatcher = jasmine.objectContaining({
+                x: 'tres',
+                y: 'cuatro',
+            });
+
+            expect(exoticLiveObject).toEqual(equalMatcher);
+            expect(plainObject).toEqual(equalMatcher);
+            expect(plainObjectNullProto).toEqual(equalMatcher);
+            expect(array).toEqual(equalMatcher);
+            expect(bigInt64Array).toEqual(equalMatcher);
+            expect(bigUint64Array).toEqual(equalMatcher);
+            expect(buffer).toEqual(equalMatcher);
+            expect(dataView).toEqual(equalMatcher);
+            expect(float32Array).toEqual(equalMatcher);
+            expect(float64Array).toEqual(equalMatcher);
+            expect(int8Array).toEqual(equalMatcher);
+            expect(int16Array).toEqual(equalMatcher);
+            expect(int32Array).toEqual(equalMatcher);
+            expect(regexp).toEqual(equalMatcher);
+            expect(uint8Array).toEqual(equalMatcher);
+            expect(uint8ClampedArray).toEqual(equalMatcher);
+            expect(uint16Array).toEqual(equalMatcher);
+            expect(uint32Array).toEqual(equalMatcher);
+        `);
+
+        const equalMatcher = jasmine.objectContaining({
+            x: 'tres',
+            y: 'cuatro',
+        });
+
+        expect(exoticLiveObject).toEqual(equalMatcher);
+        expect(plainObject).toEqual(equalMatcher);
+        expect(plainObjectNullProto).toEqual(equalMatcher);
+        expect(array).toEqual(equalMatcher);
+        expect(bigInt64Array).toEqual(equalMatcher);
+        expect(bigUint64Array).toEqual(equalMatcher);
+        expect(buffer).toEqual(equalMatcher);
+        expect(dataView).toEqual(equalMatcher);
+        expect(float32Array).toEqual(equalMatcher);
+        expect(float64Array).toEqual(equalMatcher);
+        expect(int8Array).toEqual(equalMatcher);
+        expect(int16Array).toEqual(equalMatcher);
+        expect(int32Array).toEqual(equalMatcher);
+        expect(regexp).toEqual(equalMatcher);
+        expect(uint8Array).toEqual(equalMatcher);
+        expect(uint8ClampedArray).toEqual(equalMatcher);
+        expect(uint16Array).toEqual(equalMatcher);
+        expect(uint32Array).toEqual(equalMatcher);
+    });
+    it('should allow mutation from within the sandbox', () => {
+        expect.assertions(36);
+
+        env.evaluate(`
+            const equalMatcher = jasmine.objectContaining({
+                x: 'cinco',
+                y: 'six',
+            });
+
             exoticLiveObject.x = 'cinco';
             exoticLiveObject.y = 'six';
-            expect(exoticLiveObject).toEqual(jasmine.objectContaining({ x: 'cinco', y: 'six' }));
+
             plainObject.x = 'cinco';
             plainObject.y = 'six';
-            expect(plainObject).toEqual(jasmine.objectContaining({ x: 'cinco', y: 'six' }));
+
+            plainObjectNullProto.x = 'cinco';
+            plainObjectNullProto.y = 'six';
+
+            array.x = 'cinco';
+            array.y = 'six';
+
+            bigInt64Array.x = 'cinco';
+            bigInt64Array.y = 'six';
+
+            bigUint64Array.x = 'cinco';
+            bigUint64Array.y = 'six';
+
+            buffer.x = 'cinco';
+            buffer.y = 'six';
+
+            dataView.x = 'cinco';
+            dataView.y = 'six';
+
+            float32Array.x = 'cinco';
+            float32Array.y = 'six';
+
+            float64Array.x = 'cinco';
+            float64Array.y = 'six';
+
+            int8Array.x = 'cinco';
+            int8Array.y = 'six';
+
+            int16Array.x = 'cinco';
+            int16Array.y = 'six';
+
+            int32Array.x = 'cinco';
+            int32Array.y = 'six';
+
+            regexp.x = 'cinco';
+            regexp.y = 'six';
+
+            uint8Array.x = 'cinco';
+            uint8Array.y = 'six';
+
+            uint8ClampedArray.x = 'cinco';
+            uint8ClampedArray.y = 'six';
+
+            uint16Array.x = 'cinco';
+            uint16Array.y = 'six';
+
+            uint32Array.x = 'cinco';
+            uint32Array.y = 'six';
+
+            expect(exoticLiveObject).toEqual(equalMatcher);
+            expect(plainObject).toEqual(equalMatcher);
+            expect(plainObjectNullProto).toEqual(equalMatcher);
+            expect(array).toEqual(equalMatcher);
+            expect(bigInt64Array).toEqual(equalMatcher);
+            expect(bigUint64Array).toEqual(equalMatcher);
+            expect(buffer).toEqual(equalMatcher);
+            expect(dataView).toEqual(equalMatcher);
+            expect(float32Array).toEqual(equalMatcher);
+            expect(float64Array).toEqual(equalMatcher);
+            expect(int8Array).toEqual(equalMatcher);
+            expect(int16Array).toEqual(equalMatcher);
+            expect(int32Array).toEqual(equalMatcher);
+            expect(regexp).toEqual(equalMatcher);
+            expect(uint8Array).toEqual(equalMatcher);
+            expect(uint8ClampedArray).toEqual(equalMatcher);
+            expect(uint16Array).toEqual(equalMatcher);
+            expect(uint32Array).toEqual(equalMatcher);
         `);
-        expect(exoticLiveObject).toEqual(jasmine.objectContaining({ x: 'cinco', y: 'six' }));
-        expect(plainObject).toEqual(jasmine.objectContaining({ x: 'cinco', y: 'six' }));
+
+        const equalMatcher = jasmine.objectContaining({
+            x: 'cinco',
+            y: 'six',
+        });
+
+        expect(exoticLiveObject).toEqual(equalMatcher);
+        expect(plainObject).toEqual(equalMatcher);
+        expect(plainObjectNullProto).toEqual(equalMatcher);
+        expect(array).toEqual(equalMatcher);
+        expect(bigInt64Array).toEqual(equalMatcher);
+        expect(bigUint64Array).toEqual(equalMatcher);
+        expect(buffer).toEqual(equalMatcher);
+        expect(dataView).toEqual(equalMatcher);
+        expect(float32Array).toEqual(equalMatcher);
+        expect(float64Array).toEqual(equalMatcher);
+        expect(int8Array).toEqual(equalMatcher);
+        expect(int16Array).toEqual(equalMatcher);
+        expect(int32Array).toEqual(equalMatcher);
+        expect(regexp).toEqual(equalMatcher);
+        expect(uint8Array).toEqual(equalMatcher);
+        expect(uint8ClampedArray).toEqual(equalMatcher);
+        expect(uint16Array).toEqual(equalMatcher);
+        expect(uint32Array).toEqual(equalMatcher);
     });
     it('should allow expandos added form within the sandbox', () => {
-        expect.assertions(4);
+        expect.assertions(36);
 
         env.evaluate(`
             exoticLiveObject.z = 'seven';
-            expect(exoticLiveObject.z).toBe('seven');
             plainObject.z = 'seven';
+            plainObjectNullProto.z = 'seven';
+            array.z = 'seven';
+            bigInt64Array.z = 'seven';
+            bigUint64Array.z = 'seven';
+            buffer.z = 'seven';
+            dataView.z = 'seven';
+            float32Array.z = 'seven';
+            float64Array.z = 'seven';
+            int8Array.z = 'seven';
+            int16Array.z = 'seven';
+            int32Array.z = 'seven';
+            regexp.z = 'seven';
+            uint8Array.z = 'seven';
+            uint8ClampedArray.z = 'seven';
+            uint16Array.z = 'seven';
+            uint32Array.z = 'seven';
+
+            expect(exoticLiveObject.z).toBe('seven');
             expect(plainObject.z).toBe('seven');
+            expect(plainObjectNullProto.z).toBe('seven');
+            expect(array.z).toBe('seven');
+            expect(bigInt64Array.z).toBe('seven');
+            expect(bigUint64Array.z).toBe('seven');
+            expect(buffer.z).toBe('seven');
+            expect(dataView.z).toBe('seven');
+            expect(float32Array.z).toBe('seven');
+            expect(float64Array.z).toBe('seven');
+            expect(int8Array.z).toBe('seven');
+            expect(int16Array.z).toBe('seven');
+            expect(int32Array.z).toBe('seven');
+            expect(regexp.z).toBe('seven');
+            expect(uint8Array.z).toBe('seven');
+            expect(uint8ClampedArray.z).toBe('seven');
+            expect(uint16Array.z).toBe('seven');
+            expect(uint32Array.z).toBe('seven');
         `);
+
         expect(exoticLiveObject.z).toBe('seven');
         expect(plainObject.z).toBe('seven');
+        expect(plainObjectNullProto.z).toBe('seven');
+        expect(array.z).toBe('seven');
+        expect(bigInt64Array.z).toBe('seven');
+        expect(bigUint64Array.z).toBe('seven');
+        expect(buffer.z).toBe('seven');
+        expect(dataView.z).toBe('seven');
+        expect(float32Array.z).toBe('seven');
+        expect(float64Array.z).toBe('seven');
+        expect(int8Array.z).toBe('seven');
+        expect(int16Array.z).toBe('seven');
+        expect(int32Array.z).toBe('seven');
+        expect(regexp.z).toBe('seven');
+        expect(uint8Array.z).toBe('seven');
+        expect(uint8ClampedArray.z).toBe('seven');
+        expect(uint16Array.z).toBe('seven');
+        expect(uint32Array.z).toBe('seven');
     });
-    it('should affect own properties of live objects', () => {
-        expect.assertions(5);
+    it('should affect own properties of stamped live objects', () => {
+        expect.assertions(4);
 
         exoticLiveObject.w = new ExoticObject({ x: 1 });
         env.evaluate(`
@@ -88,21 +432,160 @@ describe('a live red proxy', () => {
             exoticLiveObject.w.x = 2;
             expect({ ...exoticLiveObject.w }).toEqual({ x: 2 });
         `);
-        expect(exoticLiveObject.z).toBe('siete');
-        expect(exoticLiveObject.w).toEqual(new ExoticObject({ x: 1 }));
+
+        const equalMatcher = jasmine.objectContaining({
+            w: new ExoticObject({ x: 1 }),
+            z: 'siete',
+        });
+
+        expect(exoticLiveObject).toEqual(equalMatcher);
     });
-    it('should affect all plain object properties', () => {
-        expect.assertions(5);
+    it('should affect all unstamped live object properties', () => {
+        expect.assertions(68);
 
         plainObject.w = { x: 1 };
+        plainObjectNullProto.w = { x: 1 };
+        array.w = { x: 1 };
+        bigInt64Array.w = { x: 1 };
+        bigUint64Array.w = { x: 1 };
+        buffer.w = { x: 1 };
+        dataView.w = { x: 1 };
+        float32Array.w = { x: 1 };
+        float64Array.w = { x: 1 };
+        int8Array.w = { x: 1 };
+        int16Array.w = { x: 1 };
+        int32Array.w = { x: 1 };
+        regexp.w = { x: 1 };
+        uint8Array.w = { x: 1 };
+        uint8ClampedArray.w = { x: 1 };
+        uint16Array.w = { x: 1 };
+        uint32Array.w = { x: 1 };
+
         env.evaluate(`
             plainObject.z = 'siete';
             expect(plainObject.z).toBe('siete');
             expect(plainObject.w).toEqual({ x: 1 });
             plainObject.w.x = 2;
             expect(plainObject.w).toEqual({ x: 2 });
+
+            plainObjectNullProto.z = 'siete';
+            expect(plainObjectNullProto.z).toBe('siete');
+            expect(plainObjectNullProto.w).toEqual({ x: 1 });
+            plainObjectNullProto.w.x = 2;
+            expect(plainObjectNullProto.w).toEqual({ x: 2 });
+
+            array.z = 'siete';
+            expect(array.z).toBe('siete');
+            expect(array.w).toEqual({ x: 1 });
+            array.w.x = 2;
+            expect(array.w).toEqual({ x: 2 });
+
+            bigInt64Array.z = 'siete';
+            expect(bigInt64Array.z).toBe('siete');
+            expect(bigInt64Array.w).toEqual({ x: 1 });
+            bigInt64Array.w.x = 2;
+            expect(bigInt64Array.w).toEqual({ x: 2 });
+
+            bigUint64Array.z = 'siete';
+            expect(bigUint64Array.z).toBe('siete');
+            expect(bigUint64Array.w).toEqual({ x: 1 });
+            bigUint64Array.w.x = 2;
+            expect(bigUint64Array.w).toEqual({ x: 2 });
+
+            buffer.z = 'siete';
+            expect(buffer.z).toBe('siete');
+            expect(buffer.w).toEqual({ x: 1 });
+            buffer.w.x = 2;
+            expect(buffer.w).toEqual({ x: 2 });
+
+            dataView.z = 'siete';
+            expect(dataView.z).toBe('siete');
+            expect(dataView.w).toEqual({ x: 1 });
+            dataView.w.x = 2;
+            expect(dataView.w).toEqual({ x: 2 });
+
+            float32Array.z = 'siete';
+            expect(float32Array.z).toBe('siete');
+            expect(float32Array.w).toEqual({ x: 1 });
+            float32Array.w.x = 2;
+            expect(float32Array.w).toEqual({ x: 2 });
+
+            float64Array.z = 'siete';
+            expect(float64Array.z).toBe('siete');
+            expect(float64Array.w).toEqual({ x: 1 });
+            float64Array.w.x = 2;
+            expect(float64Array.w).toEqual({ x: 2 });
+
+            int8Array.z = 'siete';
+            expect(int8Array.z).toBe('siete');
+            expect(int8Array.w).toEqual({ x: 1 });
+            int8Array.w.x = 2;
+            expect(int8Array.w).toEqual({ x: 2 });
+
+            int16Array.z = 'siete';
+            expect(int16Array.z).toBe('siete');
+            expect(int16Array.w).toEqual({ x: 1 });
+            int16Array.w.x = 2;
+            expect(int16Array.w).toEqual({ x: 2 });
+
+            int32Array.z = 'siete';
+            expect(int32Array.z).toBe('siete');
+            expect(int32Array.w).toEqual({ x: 1 });
+            int32Array.w.x = 2;
+            expect(int32Array.w).toEqual({ x: 2 });
+
+            regexp.z = 'siete';
+            expect(regexp.z).toBe('siete');
+            expect(regexp.w).toEqual({ x: 1 });
+            regexp.w.x = 2;
+            expect(regexp.w).toEqual({ x: 2 });
+
+            uint8Array.z = 'siete';
+            expect(uint8Array.z).toBe('siete');
+            expect(uint8Array.w).toEqual({ x: 1 });
+            uint8Array.w.x = 2;
+            expect(uint8Array.w).toEqual({ x: 2 });
+
+            uint8ClampedArray.z = 'siete';
+            expect(uint8ClampedArray.z).toBe('siete');
+            expect(uint8ClampedArray.w).toEqual({ x: 1 });
+            uint8ClampedArray.w.x = 2;
+            expect(uint8ClampedArray.w).toEqual({ x: 2 });
+
+            uint16Array.z = 'siete';
+            expect(uint16Array.z).toBe('siete');
+            expect(uint16Array.w).toEqual({ x: 1 });
+            uint16Array.w.x = 2;
+            expect(uint16Array.w).toEqual({ x: 2 });
+
+            uint32Array.z = 'siete';
+            expect(uint32Array.z).toBe('siete');
+            expect(uint32Array.w).toEqual({ x: 1 });
+            uint32Array.w.x = 2;
+            expect(uint32Array.w).toEqual({ x: 2 });
         `);
-        expect(plainObject.z).toBe('siete');
-        expect(plainObject.w).toEqual({ x: 2 });
+
+        const equalMatcher = jasmine.objectContaining({
+            w: { x: 2 },
+            z: 'siete',
+        });
+
+        expect(plainObject).toEqual(equalMatcher);
+        expect(plainObjectNullProto).toEqual(equalMatcher);
+        expect(array).toEqual(equalMatcher);
+        expect(bigInt64Array).toEqual(equalMatcher);
+        expect(bigUint64Array).toEqual(equalMatcher);
+        expect(buffer).toEqual(equalMatcher);
+        expect(dataView).toEqual(equalMatcher);
+        expect(float32Array).toEqual(equalMatcher);
+        expect(float64Array).toEqual(equalMatcher);
+        expect(int8Array).toEqual(equalMatcher);
+        expect(int16Array).toEqual(equalMatcher);
+        expect(int32Array).toEqual(equalMatcher);
+        expect(regexp).toEqual(equalMatcher);
+        expect(uint8Array).toEqual(equalMatcher);
+        expect(uint8ClampedArray).toEqual(equalMatcher);
+        expect(uint16Array).toEqual(equalMatcher);
+        expect(uint32Array).toEqual(equalMatcher);
     });
 });

--- a/test/membrane/object-branding.spec.js
+++ b/test/membrane/object-branding.spec.js
@@ -54,7 +54,7 @@ describe('object-branding', () => {
     });
 
     it('should get branding of with targets with null prototypes', () => {
-        expect.assertions(28);
+        expect.assertions(39);
 
         const env = createVirtualEnvironment(window, window, {
             endowments: { expect },
@@ -64,40 +64,100 @@ describe('object-branding', () => {
                 return Object.prototype.toString.call(object).slice(8, -1);
             }
 
-            function nullProto(object) {
-                Reflect.setPrototypeOf(object, null);
+            function setProto(object, proto) {
+                Reflect.setPrototypeOf(object, proto);
                 return object;
             }
 
-            expect(getToStringTag(nullProto([]))).toBe('Array');
-            expect(getToStringTag(nullProto(new Array()))).toBe('Array');
-            expect(getToStringTag(nullProto(new Boolean(true)))).toBe('Boolean');
-            expect(getToStringTag(nullProto(function (){}))).toBe('Function');
-            expect(getToStringTag(nullProto(async ()=>{}))).toBe('Function');
-            expect(getToStringTag(nullProto(function * (){}))).toBe('Function');
-            expect(getToStringTag(nullProto(async function * (){}))).toBe('Function');
-            expect(getToStringTag(nullProto(new Date()))).toBe('Date');
-            expect(getToStringTag(nullProto({}))).toEqual('Object');
-            expect(getToStringTag(nullProto(new Number(0)))).toBe('Number');
-            expect(getToStringTag(nullProto(/a/))).toBe('RegExp');
-            expect(getToStringTag(nullProto(new RegExp('a')))).toBe('RegExp');
-            expect(getToStringTag(nullProto(new String('a')))).toBe('String');
-            expect(getToStringTag(nullProto(Object(Symbol('a'))))).toBe('Object');
+            expect(getToStringTag(setProto([], null))).toBe('Array');
+            expect(getToStringTag(setProto(new Array(), null))).toBe('Array');
+            expect(getToStringTag(setProto(new Boolean(true), null))).toBe('Boolean');
+            expect(getToStringTag(setProto(function (){}, null))).toBe('Function');
+            expect(getToStringTag(setProto(async ()=>{}, null))).toBe('Function');
+            expect(getToStringTag(setProto(function * (){}, null))).toBe('Function');
+            expect(getToStringTag(setProto(async function * (){}, null))).toBe('Function');
+            expect(getToStringTag(setProto(new Date(), null))).toBe('Date');
+            expect(getToStringTag(setProto({}, null))).toEqual('Object');
+            expect(getToStringTag(setProto(new Number(0), null))).toBe('Number');
+            expect(getToStringTag(setProto(/a/, null))).toBe('RegExp');
+            expect(getToStringTag(setProto(new RegExp('a'), null))).toBe('RegExp');
+            expect(getToStringTag(setProto(new String('a'), null))).toBe('String');
+            expect(getToStringTag(setProto(Object(Symbol('a')), null))).toBe('Object');
 
             const buffer = new ArrayBuffer(8);
-            expect(getToStringTag(nullProto(buffer))).toBe('ArrayBuffer');
-            expect(getToStringTag(nullProto(new DataView(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Float32Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Float64Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Int8Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Int16Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Int32Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Uint8Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Uint8ClampedArray(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Uint16Array(buffer)))).toBe('Object');
-            expect(getToStringTag(nullProto(new Uint32Array(buffer)))).toBe('Object');
+            const bufferProto = Reflect.getPrototypeOf(buffer);
+            expect(getToStringTag(setProto(buffer, null))).toBe('Object');
+            expect(getToStringTag(setProto(buffer, bufferProto))).toBe('ArrayBuffer');
 
-            const custom = nullProto({ [Symbol.toStringTag]: 'Custom' });
+            const dataView = new DataView(buffer);
+            const dataViewProto = Reflect.getPrototypeOf(dataView);
+            expect(getToStringTag(setProto(dataView, null))).toBe('Object');
+            expect(getToStringTag(setProto(dataView, dataViewProto))).toBe('DataView');
+
+            const float32Array = new Float32Array(buffer);
+            const float32ArrayProto = Reflect.getPrototypeOf(float32Array);
+            expect(getToStringTag(setProto(float32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(float32Array, float32ArrayProto))).toBe(
+                'Float32Array'
+            );
+
+            const float64Array = new Float64Array(buffer);
+            const float64ArrayProto = Reflect.getPrototypeOf(float64Array);
+            expect(getToStringTag(setProto(float64Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(float64Array, float64ArrayProto))).toBe(
+                'Float64Array'
+            );
+
+            const int8Array = new Int8Array(buffer);
+            const int8ArrayProto = Reflect.getPrototypeOf(int8Array);
+            expect(getToStringTag(setProto(int8Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int8Array, int8ArrayProto))).toBe(
+                'Int8Array'
+            );
+
+            const int16Array = new Int16Array(buffer);
+            const int16ArrayProto = Reflect.getPrototypeOf(int16Array);
+            expect(getToStringTag(setProto(int16Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int16Array, int8ArrayProto))).toBe(
+                'Int16Array'
+            );
+
+            const int32Array = new Int32Array(buffer);
+            const int32ArrayProto = Reflect.getPrototypeOf(int32Array);
+            expect(getToStringTag(setProto(int32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int32Array, int8ArrayProto))).toBe(
+                'Int32Array'
+            );
+
+            const uint8Array = new Uint8Array(buffer);
+            const uint8ArrayProto = Reflect.getPrototypeOf(uint8Array);
+            expect(getToStringTag(setProto(uint8Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint8Array, uint8ArrayProto))).toBe(
+                'Uint8Array'
+            );
+
+            const uint8ClampedArray = new Uint8ClampedArray(buffer);
+            const uint8ClampedArrayProto = Reflect.getPrototypeOf(uint8ClampedArray);
+            expect(getToStringTag(setProto(uint8ClampedArray, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint8ClampedArray, uint8ClampedArrayProto))).toBe(
+                'Uint8ClampedArray'
+            );
+
+            const uint16Array = new Uint16Array(buffer);
+            const uint16ArrayProto = Reflect.getPrototypeOf(uint16Array);
+            expect(getToStringTag(setProto(uint16Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint16Array, uint16ArrayProto))).toBe(
+                'Uint16Array'
+            );
+
+            const uint32Array = new Uint32Array(buffer);
+            const uint32ArrayProto = Reflect.getPrototypeOf(uint32Array);
+            expect(getToStringTag(setProto(uint32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint32Array, uint32ArrayProto))).toBe(
+                'Uint32Array'
+            );
+
+            const custom = setProto({ [Symbol.toStringTag]: 'Custom' }, null);
             expect(getToStringTag(custom)).toBe('Custom');
 
             const inheritedCustom = Object.create(custom);

--- a/test/membrane/trap-mutations.spec.js
+++ b/test/membrane/trap-mutations.spec.js
@@ -1,5 +1,7 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 
+const LOCKER_LIVE_VALUE_MARKER_SYMBOL = Symbol.for('@@lockerLiveValue');
+
 class Base {
     // eslint-disable-next-line class-methods-use-this
     get x() {
@@ -71,7 +73,7 @@ describe('trap mutations', () => {
     });
     it('should honor the marker coming from blue', () => {
         const exoticInstance = new ExoticObject();
-        exoticInstance[Symbol.for('@@lockerLiveValue')] = undefined;
+        exoticInstance[LOCKER_LIVE_VALUE_MARKER_SYMBOL] = undefined;
         expect(getPropFromRed(exoticInstance, 'y')).toBe(4);
         // The following mutation should trigger the instance of Base to
         // not be ambiguous anymore.


### PR DESCRIPTION
feat: add array buffer and regexp (because of .lastIndex) to live objects, no longer memoize toStringTags, and add lots of tests.