### PR TITLE
feat: all lint guard for prefer-object-spread in toString-able functions

### DIFF
--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -178,6 +178,7 @@ export function createMembraneMarshall(
     isInShadowRealm?: boolean,
     { proxyTargetToLazyPropertyStateMap } = sharedMembraneState
 ) {
+    /* eslint-disable prefer-object-spread */
     // @rollup/plugin-replace replaces `DEV_MODE` references.
     const DEV_MODE = true;
     const FLAGS_REG_EXP = /\w*$/;
@@ -2875,4 +2876,5 @@ export function createMembraneMarshall(
             );
         };
     };
+    /* eslint-enable prefer-object-spread */
 }


### PR DESCRIPTION
feat: all lint guard for prefer-object-spread in toString-able functions.

While we have guards in place and have explicit opt-outs before use, those are more a signal to us not to change them into an object spread. This helps prevent transforms in case they are used anyways and aligns with what we do in our `@locker/sandbox` package.