### PR TITLE
fix: downgrade karma-rollup-preprocessor to 7.0.7 to address file overwrite issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "karma-coverage": "2.2.0",
     "karma-firefox-launcher": "2.1.2",
     "karma-jasmine": "4.0.1",
-    "karma-rollup-preprocessor": "7.0.8",
+    "karma-rollup-preprocessor": "7.0.7",
     "karma-safari-launcher": "1.0.0",
     "lerna": "4.0.0",
     "lint-staged": "12.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6988,10 +6988,10 @@ karma-jasmine@4.0.1:
   dependencies:
     jasmine-core "^3.6.0"
 
-karma-rollup-preprocessor@7.0.8:
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz#5cf5ca22c815afce1ba876b56da81e81e989823e"
-  integrity sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==
+karma-rollup-preprocessor@7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.7.tgz#d06e587b108273ae564cbd5c5914a75602191a23"
+  integrity sha512-Y1QwsTCiCBp8sSALZdqmqry/mWIWIy0V6zonUIpy+0/D/Kpb2XZvR+JZrWfacQvcvKQdZFJvg6EwlnKtjepu3Q==
   dependencies:
     chokidar "^3.3.1"
     debounce "^1.2.0"


### PR DESCRIPTION
As found here: https://github.com/jlmakes/karma-rollup-preprocessor/issues/75

Related to https://github.com/salesforce/locker/pull/771