### PR TITLE
fix: create a different connector for the same window object with a different location

### DIFF
--- a/packages/near-membrane-base/src/connector.ts
+++ b/packages/near-membrane-base/src/connector.ts
@@ -6,12 +6,12 @@ export type Connector = ReturnType<typeof createMembraneMarshall>;
 const TypeErrorCtor = TypeError;
 const WeakMapCtor = WeakMap;
 
-const evaluatorToRedCreateHooksCallbackMap = toSafeWeakMap(
+const evaluatorToBlueCreateHooksCallbackMap = toSafeWeakMap(
     new WeakMapCtor<typeof eval, Connector>()
 );
 
-const globalThisToBlueCreateHooksCallbackMap = toSafeWeakMap(
-    new WeakMapCtor<typeof globalThis, Connector>()
+const evaluatorToRedCreateHooksCallbackMap = toSafeWeakMap(
+    new WeakMapCtor<typeof eval, Connector>()
 );
 
 const createMembraneMarshallSourceInStrictMode = `
@@ -22,10 +22,14 @@ export function createBlueConnector(globalObject: typeof globalThis): Connector 
     if (typeof globalObject !== 'object' || globalObject === null) {
         throw new TypeErrorCtor('Missing globalObject.');
     }
-    let createHooksCallback = globalThisToBlueCreateHooksCallbackMap.get(globalObject);
+    const { eval: evaluator } = globalObject;
+    if (typeof evaluator !== 'function') {
+        throw new TypeErrorCtor('Missing evaluator function.');
+    }
+    let createHooksCallback = evaluatorToBlueCreateHooksCallbackMap.get(evaluator);
     if (createHooksCallback === undefined) {
         createHooksCallback = createMembraneMarshall(globalObject);
-        globalThisToBlueCreateHooksCallbackMap.set(globalObject, createHooksCallback);
+        evaluatorToBlueCreateHooksCallbackMap.set(evaluator, createHooksCallback);
     }
     return createHooksCallback;
 }

--- a/test/environment/create-connector-spec.js
+++ b/test/environment/create-connector-spec.js
@@ -1,0 +1,26 @@
+import { createBlueConnector } from '@locker/near-membrane-base';
+
+/*
+    These tests are exercising the BUILT near-membrane-base,
+    ie. package/near-membrane-base/dist/index.js
+*/
+describe('createBlueConnector', () => {
+    it('creates a different connector for the same window object with a different location', async () => {
+        expect.assertions(1);
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+        const connector1 = createBlueConnector(iframe.contentWindow);
+        let resolver;
+        const promise = new Promise((resolve) => {
+            resolver = resolve;
+        });
+        iframe.addEventListener('load', () => {
+            const connector2 = createBlueConnector(iframe.contentWindow);
+            expect(connector1).not.toBe(connector2);
+            iframe.remove();
+            resolver();
+        });
+        iframe.src = 'about:blank';
+        await promise;
+    });
+});


### PR DESCRIPTION
fix: create a different connector for the same window object with a different location