### PR TITLE
fix: @W-11903379@ chore: remove JSON from ESGlobalKeys to allow distorting JSON.parse

### DIFF
--- a/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
@@ -71,7 +71,7 @@ const ESGlobalKeys = [
 
     // *** 18.4 Other Properties of the Global Object
     // 'Atomics', // Remapped
-    // 'JSON', // Remapped to distort JSON.parse`
+    // 'JSON', // Remapped
     'Math',
     'Reflect',
 

--- a/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
@@ -71,7 +71,7 @@ const ESGlobalKeys = [
 
     // *** 18.4 Other Properties of the Global Object
     // 'Atomics', // Remapped
-    'JSON',
+    // 'JSON', // Remapped to distort JSON.parse`
     'Math',
     'Reflect',
 

--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -84,7 +84,7 @@ const ESGlobalKeys = [
 
     // *** 18.4 Other Properties of the Global Object
     // 'Atomics', // Remapped
-    // 'JSON', // Remapped to distort JSON.parse
+    // 'JSON', // Remapped
     'Math',
     'Reflect',
 

--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -84,7 +84,7 @@ const ESGlobalKeys = [
 
     // *** 18.4 Other Properties of the Global Object
     // 'Atomics', // Remapped
-    'JSON',
+    // 'JSON', // Remapped to distort JSON.parse
     'Math',
     'Reflect',
 


### PR DESCRIPTION
If JSON is prevented from remapping, then the distortion for JSON.parse is not applied. Discovered via coverage reports: 

![image](https://user-images.githubusercontent.com/27985/195620433-a253222f-4354-415d-b9c7-9826a2e0eda2.png)

Tested by building this patch and local linking into locker, then running coverage. 