### PR TITLE
feat: trustedCreateScript browser env option

### DIFF
--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -84,8 +84,8 @@ function createIframeVirtualEnvironment(
         // eslint-disable-next-line prefer-object-spread
     } = options;
 
-    const trustedCreateScript =
-        typeof options.trustedCreateScript === 'function' ? options.trustedCreateScript : identity;
+    const sourceTextCallback =
+        typeof options.sourceTextCallback === 'function' ? options.sourceTextCallback : identity;
 
     const iframe = createDetachableIframe(blueRefs.document);
     const redWindow: GlobalObject = ReflectApply(
@@ -106,10 +106,10 @@ function createIframeVirtualEnvironment(
         blueCreateHooksCallbackCache.set(blueRefs.document, blueConnector);
     }
     const { eval: redIndirectEval } = redWindow;
-    const sourceTextCallback = (v: string) => redIndirectEval(trustedCreateScript(v));
+    const redEvalWithTransformations = (v: string) => redIndirectEval(sourceTextCallback(v));
     const env = new VirtualEnvironment({
         blueConnector,
-        redConnector: createRedConnector(sourceTextCallback),
+        redConnector: createRedConnector(redEvalWithTransformations),
         distortionCallback,
         instrumentation,
         liveTargetCallback,

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -7,6 +7,7 @@ import {
     VirtualEnvironment,
 } from '@locker/near-membrane-base';
 import {
+    identity,
     ObjectAssign,
     ReflectApply,
     toSafeWeakMap,
@@ -84,9 +85,7 @@ function createIframeVirtualEnvironment(
     } = options;
 
     const trustedCreateScript =
-        typeof options.trustedCreateScript === 'function'
-            ? options.trustedCreateScript
-            : (v: string) => v;
+        typeof options.trustedCreateScript === 'function' ? options.trustedCreateScript : identity;
 
     const iframe = createDetachableIframe(blueRefs.document);
     const redWindow: GlobalObject = ReflectApply(

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -84,8 +84,8 @@ function createIframeVirtualEnvironment(
         // eslint-disable-next-line prefer-object-spread
     } = options;
 
-    const sourceTextCallback =
-        typeof options.sourceTextCallback === 'function' ? options.sourceTextCallback : identity;
+    const signSourceCallback =
+        typeof options.signSourceCallback === 'function' ? options.signSourceCallback : identity;
 
     const iframe = createDetachableIframe(blueRefs.document);
     const redWindow: GlobalObject = ReflectApply(
@@ -106,10 +106,10 @@ function createIframeVirtualEnvironment(
         blueCreateHooksCallbackCache.set(blueRefs.document, blueConnector);
     }
     const { eval: redIndirectEval } = redWindow;
-    const redEvalWithTransformations = (v: string) => redIndirectEval(sourceTextCallback(v));
+    const signedRedEval = (v: string) => redIndirectEval(signSourceCallback(v));
     const env = new VirtualEnvironment({
         blueConnector,
-        redConnector: createRedConnector(redEvalWithTransformations),
+        redConnector: createRedConnector(signedRedEval),
         distortionCallback,
         instrumentation,
         liveTargetCallback,

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -107,10 +107,10 @@ function createIframeVirtualEnvironment(
         blueCreateHooksCallbackCache.set(blueRefs.document, blueConnector);
     }
     const { eval: redIndirectEval } = redWindow;
-    const signedConnectorEval = (v: string) => redIndirectEval(trustedCreateScript(v));
+    const sourceTextCallback = (v: string) => redIndirectEval(trustedCreateScript(v));
     const env = new VirtualEnvironment({
         blueConnector,
-        redConnector: createRedConnector(signedConnectorEval),
+        redConnector: createRedConnector(sourceTextCallback),
         distortionCallback,
         instrumentation,
         liveTargetCallback,

--- a/packages/near-membrane-dom/src/types.ts
+++ b/packages/near-membrane-dom/src/types.ts
@@ -11,4 +11,5 @@ export interface BrowserEnvironmentOptions {
     instrumentation?: Instrumentation;
     keepAlive?: boolean;
     liveTargetCallback?: LiveTargetCallback;
+    trustedCreateScript?: Function;
 }

--- a/packages/near-membrane-dom/src/types.ts
+++ b/packages/near-membrane-dom/src/types.ts
@@ -11,5 +11,5 @@ export interface BrowserEnvironmentOptions {
     instrumentation?: Instrumentation;
     keepAlive?: boolean;
     liveTargetCallback?: LiveTargetCallback;
-    trustedCreateScript?: Function;
+    sourceTextCallback?: Function;
 }

--- a/packages/near-membrane-dom/src/types.ts
+++ b/packages/near-membrane-dom/src/types.ts
@@ -11,5 +11,5 @@ export interface BrowserEnvironmentOptions {
     instrumentation?: Instrumentation;
     keepAlive?: boolean;
     liveTargetCallback?: LiveTargetCallback;
-    sourceTextCallback?: Function;
+    signSourceCallback?: Function;
 }

--- a/packages/near-membrane-shared/src/Function.ts
+++ b/packages/near-membrane-shared/src/Function.ts
@@ -1,3 +1,7 @@
 export function noop() {
     // No operation performed.
 }
+
+export function identity<T>(value: T): T {
+    return value;
+}


### PR DESCRIPTION
Adding an extra config options to the Browser Environment options bag. This allows passing a function which should return a TrustedType object meant to be used when creating the redConnector. This function does not propagate downstream to every `eval` call and should not do that unless there is a really solid reason to automatically sign every string we eval in the iframe.