### PR TITLE
fix: ensure red callable functions have undefined 'this' context

### DIFF
--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -69,7 +69,7 @@ export type CallableGet = (
 ) => PointerOrPrimitive;
 export type CallableGetPropertyValue = (
     targetPointer: Pointer,
-    index: PropertyKey
+    key: PropertyKey
 ) => PointerOrPrimitive;
 export type CallableGetLazyPropertyDescriptorStateByTarget = (
     targetPointer: Pointer


### PR DESCRIPTION
fix: ensure red callable functions have undefined 'this' context