### PR TITLE
fix: revert env.installRemapOverrides() to bring back later

### DIFF
--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -14,7 +14,6 @@ import type {
     CallableDescriptorCallback,
     CallableEvaluate,
     CallableGetPropertyValuePointer,
-    CallableInstallJSONStringify,
     CallableInstallLazyPropertyDescriptors,
     CallableIsTargetLive,
     CallableIsTargetRevoked,
@@ -30,8 +29,6 @@ import type {
 } from './types';
 
 const LOCKER_NEAR_MEMBRANE_UNDEFINED_VALUE_SYMBOL = SymbolFor('@@lockerNearMembraneUndefinedValue');
-
-const WindowJSON = JSON;
 
 export class VirtualEnvironment {
     private readonly blueCallableGetPropertyValuePointer: CallableGetPropertyValuePointer;
@@ -49,8 +46,6 @@ export class VirtualEnvironment {
     private readonly redCallableEvaluate: CallableEvaluate;
 
     private readonly redCallableGetPropertyValuePointer: CallableGetPropertyValuePointer;
-
-    private readonly redCallableInstallJSONStringify: CallableInstallJSONStringify;
 
     private readonly redCallableInstallLazyPropertyDescriptors: CallableInstallLazyPropertyDescriptors;
 
@@ -119,16 +114,15 @@ export class VirtualEnvironment {
             25: blueCallableGetTargetIntegrityTraits,
             26: blueCallableGetToStringTagOfTarget,
             27: blueCallableInstallErrorPrepareStackTrace,
-            // 28: blueCallableInstallJSONStringify,
-            // 29: blueCallableInstallLazyPropertyDescriptors,
-            30: blueCallableIsTargetLive,
-            // 31: blueCallableIsTargetRevoked,
-            // 32: blueCallableSerializeTarget,
-            33: blueCallableSetLazyPropertyDescriptorStateByTarget,
-            // 34: blueTrackAsFastTarget,
-            35: blueCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
-            36: blueCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
-            37: blueCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
+            // 28: blueCallableInstallLazyPropertyDescriptors,
+            29: blueCallableIsTargetLive,
+            // 30: blueCallableIsTargetRevoked,
+            // 31: blueCallableSerializeTarget,
+            32: blueCallableSetLazyPropertyDescriptorStateByTarget,
+            // 33: blueTrackAsFastTarget,
+            34: blueCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
+            35: blueCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
+            36: blueCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
         } = blueHooks!;
         let redHooks: Parameters<HooksCallback>;
         const redConnect = redConnector('red', (...hooks: Parameters<HooksCallback>) => {
@@ -163,16 +157,15 @@ export class VirtualEnvironment {
             25: redCallableGetTargetIntegrityTraits,
             26: redCallableGetToStringTagOfTarget,
             27: redCallableInstallErrorPrepareStackTrace,
-            28: redCallableInstallJSONStringify,
-            29: redCallableInstallLazyPropertyDescriptors,
-            // 30: redCallableIsTargetLive,
-            31: redCallableIsTargetRevoked,
-            32: redCallableSerializeTarget,
-            33: redCallableSetLazyPropertyDescriptorStateByTarget,
-            34: redCallableTrackAsFastTarget,
-            35: redCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
-            36: redCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
-            37: redCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
+            28: redCallableInstallLazyPropertyDescriptors,
+            // 29: redCallableIsTargetLive,
+            30: redCallableIsTargetRevoked,
+            31: redCallableSerializeTarget,
+            32: redCallableSetLazyPropertyDescriptorStateByTarget,
+            33: redCallableTrackAsFastTarget,
+            34: redCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
+            35: redCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
+            36: redCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
         } = redHooks!;
         blueConnect(
             noop, // redGlobalThisPointer,
@@ -203,7 +196,6 @@ export class VirtualEnvironment {
             redCallableGetTargetIntegrityTraits,
             redCallableGetToStringTagOfTarget,
             redCallableInstallErrorPrepareStackTrace,
-            noop, // redCallableInstallJSONStringify
             noop, // redCallableInstallLazyPropertyDescriptors,
             noop as unknown as CallableIsTargetLive, // redCallableIsTargetLive,
             redCallableIsTargetRevoked,
@@ -243,7 +235,6 @@ export class VirtualEnvironment {
             blueCallableGetTargetIntegrityTraits,
             blueCallableGetToStringTagOfTarget,
             blueCallableInstallErrorPrepareStackTrace,
-            noop, // blueCallableInstallJSONStringify
             noop, // blueCallableInstallLazyPropertyDescriptors,
             blueCallableIsTargetLive,
             noop as unknown as CallableIsTargetRevoked, // blueCallableIsTargetRevoked,
@@ -285,8 +276,6 @@ export class VirtualEnvironment {
             }
             ReflectApply(redCallableDefineProperties, undefined, args);
         };
-        this.redCallableInstallJSONStringify = (WindowJSONPointer: Pointer) =>
-            redCallableInstallJSONStringify(WindowJSONPointer);
         this.redCallableInstallLazyPropertyDescriptors = (
             targetPointer: Pointer,
             ...ownKeysAndUnforgeableGlobalThisKeys: PropertyKey[]
@@ -314,12 +303,6 @@ export class VirtualEnvironment {
         } catch (error: any) {
             throw this.blueGetSelectedTarget() ?? error;
         }
-    }
-
-    installRemapOverrides() {
-        const transferableWindowJSON = this.blueGetTransferableValue(WindowJSON) as Pointer;
-        this.redCallableTrackAsFastTarget(transferableWindowJSON);
-        this.redCallableInstallJSONStringify(transferableWindowJSON);
     }
 
     lazyRemapProperties(

--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -287,7 +287,6 @@ export function createMembraneMarshall(
 
     // Install flags to ensure things are installed once per realm.
     let installedErrorPrepareStackTraceFlag = false;
-    let installedJSONStringifyFlag = false;
     let installedPropertyDescriptorMethodWrappersFlag = false;
 
     // eslint-disable-next-line no-shadow
@@ -4426,19 +4425,6 @@ export function createMembraneMarshall(
             },
             // callableInstallErrorPrepareStackTrace
             installErrorPrepareStackTrace,
-            // callableInstallJSONStringify
-            IS_IN_SHADOW_REALM
-                ? (WindowJSONPointer: Pointer) => {
-                      if (installedJSONStringifyFlag) {
-                          return;
-                      }
-                      installedJSONStringifyFlag = true;
-                      WindowJSONPointer();
-                      const WindowJSON = selectedTarget as typeof JSON;
-                      selectedTarget = undefined;
-                      WindowJSON.stringify = JSONStringify;
-                  }
-                : noop,
             // callableInstallLazyPropertyDescriptors
             IS_IN_SHADOW_REALM
                 ? (
@@ -4786,16 +4772,15 @@ export function createMembraneMarshall(
                 25: foreignCallableGetTargetIntegrityTraits,
                 26: foreignCallableGetToStringTagOfTarget,
                 27: foreignCallableInstallErrorPrepareStackTrace,
-                // 28: callableInstallJSONStringify,
-                // 29: callableInstallLazyPropertyDescriptors,
-                30: foreignCallableIsTargetLive,
-                31: foreignCallableIsTargetRevoked,
-                32: foreignCallableSerializeTarget,
-                33: foreignCallableSetLazyPropertyDescriptorStateByTarget,
-                // 34: callableTrackAsFastTarget,
-                35: foreignCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
-                36: foreignCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
-                37: foreignCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
+                // 28: callableInstallLazyPropertyDescriptors,
+                29: foreignCallableIsTargetLive,
+                30: foreignCallableIsTargetRevoked,
+                31: foreignCallableSerializeTarget,
+                32: foreignCallableSetLazyPropertyDescriptorStateByTarget,
+                // 33: callableTrackAsFastTarget,
+                34: foreignCallableBatchGetPrototypeOfAndGetOwnPropertyDescriptors,
+                35: foreignCallableBatchGetPrototypeOfWhenHasNoOwnProperty,
+                36: foreignCallableBatchGetPrototypeOfWhenHasNoOwnPropertyDescriptor,
             } = hooks);
             const applyTrapForZeroOrMoreArgs = createApplyOrConstructTrapForZeroOrMoreArgs(
                 ProxyHandlerTraps.Apply

--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -85,7 +85,6 @@ export type CallableGetTargetIntegrityTraits = (targetPointer: Pointer) => numbe
 export type CallableGetToStringTagOfTarget = (targetPointer: Pointer) => string;
 export type CallableHas = (targetPointer: Pointer, key: PropertyKey) => boolean;
 export type CallableInstallErrorPrepareStackTrace = () => void;
-export type CallableInstallJSONStringify = (WindowJSONPointer: Pointer) => void;
 export type CallableInstallLazyPropertyDescriptors = (
     targetPointer: Pointer,
     ...ownKeysAndUnforgeableGlobalThisKeys: PropertyKey[]
@@ -166,7 +165,6 @@ export type HooksCallback = (
     callableGetTargetIntegrityTraits: CallableGetTargetIntegrityTraits,
     callableGetToStringTagOfTarget: CallableGetToStringTagOfTarget,
     callableInstallErrorPrepareStackTrace: CallableInstallErrorPrepareStackTrace,
-    callableInstallJSONStringify: CallableInstallJSONStringify,
     callableInstallLazyPropertyDescriptors: CallableInstallLazyPropertyDescriptors,
     callableIsTargetLive: CallableIsTargetLive,
     callableIsTargetRevoked: CallableIsTargetRevoked,

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -150,7 +150,6 @@ function createIframeVirtualEnvironment(
     // We intentionally skip remapping Window.prototype because there is nothing
     // in it that needs to be remapped.
     env.lazyRemapProperties(blueRefs.EventTargetProto, blueRefs.EventTargetProtoOwnKeys);
-    env.installRemapOverrides();
     // We don't remap `blueRefs.WindowPropertiesProto` because it is "magical"
     // in that it provides access to elements by id.
     //

--- a/packages/near-membrane-node/src/node-realm.ts
+++ b/packages/near-membrane-node/src/node-realm.ts
@@ -74,6 +74,5 @@ export default function createVirtualEnvironment(
         assignFilteredGlobalDescriptorsFromPropertyDescriptorMap(filteredEndowments, endowments);
         env.remapProperties(globalObject, filteredEndowments);
     }
-    env.installRemapOverrides();
     return env;
 }

--- a/test/membrane/json.spec.js
+++ b/test/membrane/json.spec.js
@@ -1,7 +1,8 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 
 describe('JSON', () => {
-    it('JSON.stringify of blue objects with modified properties', () => {
+    // @TODO: Fix in 246 with performance optimization.
+    xit('stringify of blue objects with modified properties', () => {
         expect.assertions(1);
 
         let takeInside;
@@ -24,7 +25,7 @@ describe('JSON', () => {
         takeInside(outsideObject, JSON.stringify({ blue: true, red: true }));
     });
 
-    it('JSON.stringify of blue objects with date, rect, and regexp properties', () => {
+    it('stringify of blue objects with date, rect, and regexp properties', () => {
         expect.assertions(1);
 
         let takeInside;
@@ -49,7 +50,7 @@ describe('JSON', () => {
         takeInside(outsideObject, JSON.stringify({ date, rect, regexp }));
     });
 
-    it('JSON.stringify of red objects with modified properties', () => {
+    it('stringify of red objects with modified properties', () => {
         expect.assertions(1);
 
         const env = createVirtualEnvironment(window, {
@@ -68,7 +69,7 @@ describe('JSON', () => {
         `);
     });
 
-    it('JSON.stringify of red objects with date, rect, and regexp properties', () => {
+    it('stringify of red objects with date, rect, and regexp properties', () => {
         expect.assertions(1);
 
         const date = new Date();


### PR DESCRIPTION
fix: revert `env.installRemapOverrides()` to bring back later to fix a performance regression.

- [x] ~~Please merge #421 then rebase this to merge.~~