### PR TITLE
chore: Guard for Jest DOM

### DIFF
--- a/packages/near-membrane-dom/src/window.ts
+++ b/packages/near-membrane-dom/src/window.ts
@@ -55,7 +55,7 @@ export function getCachedGlobalObjectReferences(
         WindowProto: ReflectGetPrototypeOf(window)!,
         WindowPropertiesProto: ReflectGetPrototypeOf(WindowProto)!,
         EventTargetProto,
-        EventTargetProtoOwnKeys: ReflectOwnKeys(EventTargetProto),
+        EventTargetProtoOwnKeys: EventTargetProto ? ReflectOwnKeys(EventTargetProto) : [],
     } as CachedBlueReferencesRecord;
     blueDocumentToRecordMap.set(document, record);
     return record;

--- a/packages/near-membrane-dom/src/window.ts
+++ b/packages/near-membrane-dom/src/window.ts
@@ -55,6 +55,7 @@ export function getCachedGlobalObjectReferences(
         WindowProto: ReflectGetPrototypeOf(window)!,
         WindowPropertiesProto: ReflectGetPrototypeOf(WindowProto)!,
         EventTargetProto,
+        // Some simulated browser environments, e.g. those using JSDOM, may lack an EventTargetProto.
         EventTargetProtoOwnKeys: EventTargetProto ? ReflectOwnKeys(EventTargetProto) : [],
     } as CachedBlueReferencesRecord;
     blueDocumentToRecordMap.set(document, record);


### PR DESCRIPTION
DOM used by Jest is missing some functionality. This is to guard against a null EventTargetProto