### PR TITLE
feat: optional TypeArrays remapping in realm

### DIFF
--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -80,6 +80,7 @@ function createIframeVirtualEnvironment(
         instrumentation,
         keepAlive = true,
         liveTargetCallback,
+        remapTypedArrays,
         signSourceCallback,
         // eslint-disable-next-line prefer-object-spread
     } = ObjectAssign({ __proto__: null }, providedOptions) as BrowserEnvironmentOptions;
@@ -92,7 +93,9 @@ function createIframeVirtualEnvironment(
     const shouldUseDefaultGlobalOwnKeys =
         typeof globalObjectShape !== 'object' || globalObjectShape === null;
     if (shouldUseDefaultGlobalOwnKeys && defaultGlobalOwnKeys === null) {
-        defaultGlobalOwnKeys = filterWindowKeys(getFilteredGlobalOwnKeys(redWindow));
+        defaultGlobalOwnKeys = filterWindowKeys(
+            getFilteredGlobalOwnKeys(redWindow, remapTypedArrays)
+        );
     }
     let blueConnector = blueCreateHooksCallbackCache.get(blueRefs.document) as
         | Connector
@@ -151,7 +154,11 @@ function createIframeVirtualEnvironment(
     );
     if (endowments) {
         const filteredEndowments: PropertyDescriptorMap = {};
-        assignFilteredGlobalDescriptorsFromPropertyDescriptorMap(filteredEndowments, endowments);
+        assignFilteredGlobalDescriptorsFromPropertyDescriptorMap(
+            filteredEndowments,
+            endowments,
+            remapTypedArrays
+        );
         removeWindowDescriptors(filteredEndowments);
         env.remapProperties(blueRefs.window, filteredEndowments);
     }

--- a/packages/near-membrane-dom/src/types.ts
+++ b/packages/near-membrane-dom/src/types.ts
@@ -13,5 +13,6 @@ export interface BrowserEnvironmentOptions {
     instrumentation?: Instrumentation;
     keepAlive?: boolean;
     liveTargetCallback?: LiveTargetCallback;
+    remapTypedArrays?: boolean;
     signSourceCallback?: SignSourceCallback;
 }

--- a/packages/near-membrane-node/src/node-realm.ts
+++ b/packages/near-membrane-node/src/node-realm.ts
@@ -33,6 +33,7 @@ export default function createVirtualEnvironment(
         globalObjectShape,
         instrumentation,
         liveTargetCallback,
+        remapTypedArrays,
         signSourceCallback,
     } = ObjectAssign({ __proto__: null }, providedOptions) as NodeEnvironmentOptions;
     let blueConnector = blueCreateHooksCallbackCache.get(globalObject) as Connector | undefined;
@@ -59,7 +60,7 @@ export default function createVirtualEnvironment(
     const shouldUseDefaultGlobalOwnKeys =
         typeof globalObjectShape !== 'object' || globalObjectShape === null;
     if (shouldUseDefaultGlobalOwnKeys && defaultGlobalOwnKeys === null) {
-        defaultGlobalOwnKeys = getFilteredGlobalOwnKeys(redGlobalObject);
+        defaultGlobalOwnKeys = getFilteredGlobalOwnKeys(redGlobalObject, remapTypedArrays);
     }
 
     env.lazyRemapProperties(
@@ -71,7 +72,11 @@ export default function createVirtualEnvironment(
 
     if (endowments) {
         const filteredEndowments = {};
-        assignFilteredGlobalDescriptorsFromPropertyDescriptorMap(filteredEndowments, endowments);
+        assignFilteredGlobalDescriptorsFromPropertyDescriptorMap(
+            filteredEndowments,
+            endowments,
+            remapTypedArrays
+        );
         env.remapProperties(globalObject, filteredEndowments);
     }
     return env;

--- a/packages/near-membrane-node/src/types.ts
+++ b/packages/near-membrane-node/src/types.ts
@@ -11,5 +11,6 @@ export interface NodeEnvironmentOptions {
     globalObjectShape?: object;
     instrumentation?: Instrumentation;
     liveTargetCallback?: LiveTargetCallback;
+    remapTypedArrays?: boolean;
     signSourceCallback?: SignSourceCallback;
 }


### PR DESCRIPTION
Introducing a new configuration option when a VirtualEnvironment is being created: `remapTypedArrays`. 

This allows the creator of the sandbox to control whether TypeArrays will use the environment's own prototypes (Red) or the Blue ones. 

In situations where a specific piece of code does TypeArrays manipulation at scale (50k+ entries) this option could be considered in order to drastically improve performance of the code running in the Red realm.

By default remapping is enabled and the option requires passing explicitly `false` in order to be disabled.