### PR TITLE
@W-16404595: Add Identity Discontinuity test cases for MaxPerfMode to near-membrane's binary data tests

### DIFF
--- a/test/membrane/binary-data.spec.js
+++ b/test/membrane/binary-data.spec.js
@@ -327,3 +327,50 @@ describe('FileSaver library', () => {
         `);
     });
 });
+
+describe('Identity Discontinuity', () => {
+    beforeEach(createEnvironmentThatAlwaysRemapsTypedArray);
+
+    function getBlueBlob() {
+        return new Blob([new Uint8Array([1, 2, 3])], { type: 'text/plain;charset=utf-8' });
+    }
+
+    it('can save blue blob', (done) => {
+        const env = createVirtualEnvironment(window, {
+            endowments: Object.getOwnPropertyDescriptors({ done, expect, getBlueBlob }),
+        });
+
+        env.evaluate(`
+            ${untrusted('FileSaver.js')}
+            const transferBlueBlob = false;
+            const expectedToThrow = false;
+            ${untrusted('FileSaver-blue-blob.js')}
+        `);
+    });
+    it('fails to save blue blob, when maxPerfMode is true and blob is not transferred to red', (done) => {
+        const env = createVirtualEnvironment(window, {
+            endowments: Object.getOwnPropertyDescriptors({ done, expect, getBlueBlob }),
+            maxPerfMode: true,
+        });
+
+        env.evaluate(`
+            ${untrusted('FileSaver.js')}
+            const transferBlueBlob = false;
+            const expectedToThrow = true;
+            ${untrusted('FileSaver-blue-blob.js')}
+        `);
+    });
+    it('can save blue blob, when maxPerfMode is true and blob is transferred to red', (done) => {
+        const env = createVirtualEnvironment(window, {
+            endowments: Object.getOwnPropertyDescriptors({ done, expect, getBlueBlob }),
+            maxPerfMode: true,
+        });
+
+        env.evaluate(`
+            ${untrusted('FileSaver.js')}
+            const transferBlueBlob = true;
+            const expectedToThrow = false;
+            ${untrusted('FileSaver-blue-blob.js')}
+        `);
+    });
+});

--- a/test/membrane/untrusted/binary-data/FileSaver-blue-blob.js
+++ b/test/membrane/untrusted/binary-data/FileSaver-blue-blob.js
@@ -1,0 +1,46 @@
+function blueBlobToRedBlob(blueBlob) {
+    const reader = blueBlob.stream().getReader();
+    let result = new Uint8Array(0);
+    let resolve, reject;
+    const promise = new Promise((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
+    });
+    const handler = ({ done, value }) => {
+        try {
+            if (done) {
+                const redBlob = new Blob([result.buffer], { type: blueBlob.type });
+                resolve(redBlob);
+                return;
+            }
+            const merge = new Uint8Array(result.length + value.length);
+            merge.set(result);
+            merge.set(value, result.length);
+            result = merge;
+            return reader.read().then(handler, reject);
+        } catch (e) {
+            reject(e);
+        }
+    };
+    reader.read().then(handler, reject);
+    return promise;
+}
+
+const blueBlob = getBlueBlob();
+
+const blobToSavePromise = transferBlueBlob
+    ? blueBlobToRedBlob(blueBlob)
+    : Promise.resolve(blueBlob);
+
+blobToSavePromise.then((blobToSave) => {
+    if (expectedToThrow) {
+        expect(() => {
+            saveAs(blobToSave, 'blue-binary.txt');
+        }).toThrow();
+    } else {
+        expect(() => {
+            saveAs(blobToSave, 'blue-binary.txt');
+        }).not.toThrow();
+    }
+    done();
+});


### PR DESCRIPTION
[W-16404595](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001y5CERYA2/view): Add Identity Discontinuity test cases for MaxPerfMode to near-membrane's binary data tests