### PR TITLE
fix: @W-17310064 [LWS] Add TextDecoder to near-membrane maxPerfMode keys to fix "TypeError: parameter 1 is not of type 'ArrayBuffer'"

### DIFF
--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -124,6 +124,8 @@ function getESGlobalKeys(maxPerfMode: boolean) {
             'Request',
             'Response',
             'SubtleCrypto',
+            'TextDecoder',
+            'TextEncoder',
             'URL',
             'XMLHttpRequest',
         ],

--- a/test/membrane/binary-data.spec.js
+++ b/test/membrane/binary-data.spec.js
@@ -398,6 +398,46 @@ describe('Binary Data and maxPerfMode:', () => {
         });
     });
 
+    describe('TextDecoder:', () => {
+        beforeEach(createBaseLineMaxCompatModeEnvironment);
+
+        it('can decode from typed array', () => {
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ expect }),
+            });
+
+            env.evaluate(untrusted('text-decoder.js'));
+        });
+        it('can decode from typed array, when maxPerfMode is true', () => {
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ expect }),
+                maxPerfMode: true,
+            });
+
+            env.evaluate(untrusted('text-decoder.js'));
+        });
+    });
+
+    describe('TextEncoder:', () => {
+        beforeEach(createBaseLineMaxCompatModeEnvironment);
+
+        it('can encode into typed array', () => {
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ expect }),
+            });
+
+            env.evaluate(untrusted('text-encoder.js'));
+        });
+        it('can encode into typed array, when maxPerfMode is true', () => {
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ expect }),
+                maxPerfMode: true,
+            });
+
+            env.evaluate(untrusted('text-encoder.js'));
+        });
+    });
+
     describe('FileSaver library:', () => {
         beforeEach(createBaseLineMaxCompatModeEnvironment);
 

--- a/test/membrane/untrusted/binary-data/text-decoder.js
+++ b/test/membrane/untrusted/binary-data/text-decoder.js
@@ -1,0 +1,1 @@
+new TextDecoder().decode(Uint8Array.from('Hello World!'.split('').map(letter => letter.charCodeAt(0))));

--- a/test/membrane/untrusted/binary-data/text-encoder.js
+++ b/test/membrane/untrusted/binary-data/text-encoder.js
@@ -1,0 +1,1 @@
+new TextEncoder().encodeInto('hello', new Uint8Array(8), 0);


### PR DESCRIPTION
[W-17310064](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000025zvbyYAA/view?ws=%2Flightning%2Fr%2FADM_Work__c%2Fa07EE000023VcfqYAC%2Fview): [LWS] Add TextDecoder to near-membrane maxPerfMode keys to fix "TypeError: parameter 1 is not of type 'ArrayBuffer'" | Work