### PR TITLE
fix: @W-21923786 [LWS][264] Remove eval linking in near-membrane

### DIFF
--- a/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
+++ b/packages/near-membrane-base/src/__tests__/intrinsics.spec.ts
@@ -16,7 +16,7 @@ const ESGlobalKeys = [
     'undefined',
 
     // *** 19.2 Function Properties of the Global Object
-    // 'eval', // dangerous & Reflective
+    'eval',
     'isFinite',
     'isNaN',
     'parseFloat',
@@ -83,7 +83,6 @@ const ReflectiveIntrinsicObjectNames = [
     'SyntaxError',
     'TypeError',
     'URIError',
-    'eval',
     'globalThis',
 ];
 
@@ -261,5 +260,20 @@ describe('linkIntrinsics()', () => {
         linkIntrinsics(env, {});
 
         expect(count).toBe(0);
+    });
+    it('does not link eval as a reflective intrinsic', () => {
+        const env = new VirtualEnvironment({
+            blueConnector: createBlueConnector(globalThis as any),
+            redConnector: createRedConnector(globalThis.eval),
+        });
+        env.link('globalThis');
+
+        const linkedNames: string[] = [];
+        env.link = (globalName: string) => {
+            linkedNames.push(globalName);
+        };
+        linkIntrinsics(env, globalThis);
+
+        expect(linkedNames).not.toContain('eval');
     });
 });

--- a/packages/near-membrane-base/src/intrinsics.ts
+++ b/packages/near-membrane-base/src/intrinsics.ts
@@ -36,7 +36,7 @@ function getESGlobalKeys(maxPerfMode: boolean) {
         'undefined',
 
         // *** 19.2 Function Properties of the Global Object
-        // 'eval', // dangerous & Reflective
+        'eval',
         'isFinite',
         'isNaN',
         'parseFloat',
@@ -152,7 +152,6 @@ const ReflectiveIntrinsicObjectNames = [
     'SyntaxError',
     'TypeError',
     'URIError',
-    'eval',
     'globalThis',
 ];
 


### PR DESCRIPTION
### Security Vulnerability Addressed

This commit hardens intrinsic linking by removing `eval` from the reflective-linking path while still treating it as a reserved ES global name. In near-membrane, reflective intrinsics are explicitly linked across realms by `linkIntrinsics()`. Having `eval` in that reflective list created an unnecessary capability bridge for one of the most sensitive globals.

Because near-membrane virtualization depends on careful control of which globals are linked versus remapped, linking `eval` as a reflective intrinsic risked exposing a direct evaluator with cross-realm identity semantics that were broader than intended. The risky paths were:

1. **Evaluator capability propagation** — `env.link('eval')` could propagate direct `eval` reachability through the reflective intrinsic path instead of keeping it out of that trust category.
2. **Policy mismatch** — the code comments already classify `eval` as dangerous; keeping it reflective contradicted that policy and made future regressions more likely.
3. **Cross-realm consistency drift** — treating `eval` both as global bookkeeping and as reflective intrinsic made the model harder to reason about and easier to misuse.

### Technical Implementation

The implementation changes two classification lists in `packages/near-membrane-base/src/intrinsics.ts` so `eval` is handled only as an ES global key, not as a reflective intrinsic. Concretely, `eval` is present in `getESGlobalKeys()` and removed from `ReflectiveIntrinsicObjectNames`. That means filtering APIs still recognize `eval` as a built-in global name, but `linkIntrinsics()` no longer attempts `env.link('eval')`.

This is a targeted classification fix: no changes were made to connector internals or descriptor-copy mechanics. The behavioral effect is isolated to intrinsic linking policy, which is exactly where this concern belongs.

### Key Security Properties

- `eval` is no longer linked through the reflective intrinsic channel.
- ES-global filtering behavior remains explicit and deterministic for `eval`.
- The dangerous global stays accounted for in intrinsic name filtering without being granted reflective-link treatment.
- The policy now matches existing source-level intent (`eval` marked as dangerous).

### Test Coverage

`packages/near-membrane-base/src/__tests__/intrinsics.spec.ts` was updated in lockstep with the runtime classification and adds a focused regression test for `linkIntrinsics()`.

The new test constructs a `VirtualEnvironment`, intercepts `env.link` calls, runs `linkIntrinsics(env, globalThis)`, and asserts that `'eval'` is not linked. Existing list-based tests were also updated so expected intrinsic sets match runtime behavior. This gives direct proof that `eval` is excluded from reflective linking while remaining part of ES global classification.

### Supporting Changes

There are no supporting doc/lint/tooling changes in this commit. Scope is intentionally small: runtime intrinsic classification plus tests.

### Security Implications

Before this commit, `eval` could be pulled into the reflective intrinsic linking pipeline, creating unnecessary evaluator capability exposure and policy inconsistency. After this commit, `eval` is still recognized in ES global filtering, but it is no longer linked as a reflective intrinsic, reducing capability surface and aligning behavior with the intended “dangerous” handling model.