### PR TITLE
fix: @W-21607885 Block distorted properties from being deleted

### DIFF
--- a/packages/near-membrane-base/src/environment.ts
+++ b/packages/near-membrane-base/src/environment.ts
@@ -68,6 +68,7 @@ export class VirtualEnvironment {
             distortionCallback,
             instrumentation,
             liveTargetCallback,
+            protectDistortions,
             revokedProxyCallback,
             signSourceCallback,
             // eslint-disable-next-line prefer-object-spread
@@ -82,6 +83,7 @@ export class VirtualEnvironment {
                 distortionCallback,
                 instrumentation,
                 liveTargetCallback,
+                protectDistortions,
                 revokedProxyCallback,
             }
         );

--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -674,6 +674,7 @@ export function createMembraneMarshall(
         const {
             distortionCallback,
             liveTargetCallback,
+            protectDistortions,
             revokedProxyCallback,
             // eslint-disable-next-line prefer-object-spread
         } = ObjectAssign({ __proto__: null }, options);
@@ -3776,6 +3777,31 @@ export function createMembraneMarshall(
                 targetPointer();
                 const target = selectedTarget!;
                 selectedTarget = undefined;
+                if (protectDistortions && distortionCallback) {
+                    let safeDesc;
+                    try {
+                        safeDesc = ReflectGetOwnPropertyDescriptor(target, key);
+                    } catch (error: any) {
+                        throw pushErrorAcrossBoundary(error);
+                    }
+                    if (safeDesc) {
+                        ReflectSetPrototypeOf(safeDesc, null);
+                        const { get: getter, set: setter, value } = safeDesc;
+                        if (
+                            (typeof getter === 'function' &&
+                                distortionCallback(getter) !== getter) ||
+                            (typeof setter === 'function' &&
+                                distortionCallback(setter) !== setter) ||
+                            (((typeof value === 'object' && value !== null) ||
+                                typeof value === 'function') &&
+                                distortionCallback(value) !== value)
+                        ) {
+                            throw pushErrorAcrossBoundary(
+                                new TypeErrorCtor('Cannot delete property with a distortion.')
+                            );
+                        }
+                    }
+                }
                 try {
                     return ReflectDeleteProperty(target, key);
                 } catch (error: any) {

--- a/packages/near-membrane-base/src/types.ts
+++ b/packages/near-membrane-base/src/types.ts
@@ -179,6 +179,7 @@ export interface HooksOptions {
     distortionCallback?: DistortionCallback;
     instrumentation?: Instrumentation;
     liveTargetCallback?: LiveTargetCallback;
+    protectDistortions?: boolean;
     revokedProxyCallback?: RevokedProxyCallback;
 }
 export interface Instrumentation {
@@ -200,6 +201,7 @@ export interface VirtualEnvironmentOptions {
     distortionCallback?: DistortionCallback;
     instrumentation?: Instrumentation;
     liveTargetCallback?: LiveTargetCallback;
+    protectDistortions?: boolean;
     revokedProxyCallback?: RevokedProxyCallback;
     signSourceCallback?: SignSourceCallback;
 }

--- a/packages/near-membrane-dom/src/browser-realm.ts
+++ b/packages/near-membrane-dom/src/browser-realm.ts
@@ -79,6 +79,7 @@ function createIframeVirtualEnvironment(
         keepAlive = true,
         liveTargetCallback,
         maxPerfMode = false,
+        protectDistortions = false,
         signSourceCallback,
         // eslint-disable-next-line prefer-object-spread
     } = ObjectAssign({ __proto__: null }, providedOptions) as BrowserEnvironmentOptions;
@@ -115,6 +116,7 @@ function createIframeVirtualEnvironment(
         distortionCallback,
         instrumentation,
         liveTargetCallback,
+        protectDistortions,
         revokedProxyCallback: keepAlive ? revokedProxyCallback : undefined,
         signSourceCallback,
     });

--- a/packages/near-membrane-dom/src/types.ts
+++ b/packages/near-membrane-dom/src/types.ts
@@ -14,5 +14,6 @@ export interface BrowserEnvironmentOptions {
     keepAlive?: boolean;
     liveTargetCallback?: LiveTargetCallback;
     maxPerfMode?: boolean;
+    protectDistortions?: boolean;
     signSourceCallback?: SignSourceCallback;
 }

--- a/packages/near-membrane-node/src/node-realm.ts
+++ b/packages/near-membrane-node/src/node-realm.ts
@@ -34,6 +34,7 @@ export default function createVirtualEnvironment(
         instrumentation,
         liveTargetCallback,
         maxPerfMode = false,
+        protectDistortions = false,
         signSourceCallback,
     } = ObjectAssign({ __proto__: null }, providedOptions) as NodeEnvironmentOptions;
     let blueConnector = blueCreateHooksCallbackCache.get(globalObject) as Connector | undefined;
@@ -53,6 +54,7 @@ export default function createVirtualEnvironment(
         distortionCallback,
         instrumentation,
         liveTargetCallback,
+        protectDistortions,
         signSourceCallback,
     });
     linkIntrinsics(env, globalObject);

--- a/packages/near-membrane-node/src/types.ts
+++ b/packages/near-membrane-node/src/types.ts
@@ -12,5 +12,6 @@ export interface NodeEnvironmentOptions {
     instrumentation?: Instrumentation;
     liveTargetCallback?: LiveTargetCallback;
     maxPerfMode?: boolean;
+    protectDistortions?: boolean;
     signSourceCallback?: SignSourceCallback;
 }

--- a/test/distortions/protect-distortions.spec.js
+++ b/test/distortions/protect-distortions.spec.js
@@ -1,0 +1,120 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+const originalHostDesc = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host');
+const { get: hostGetter } = originalHostDesc;
+
+const distortionMap = new Map([[hostGetter, () => null]]);
+
+function distortionCallback(v) {
+    return distortionMap.get(v) ?? v;
+}
+
+describe('protectDistortions', () => {
+    afterEach(() => {
+        if (!Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host')) {
+            Object.defineProperty(ShadowRoot.prototype, 'host', originalHostDesc);
+        }
+    });
+
+    describe('when enabled', () => {
+        it('should throw when deleting a property whose getter is distorted', () => {
+            expect.assertions(1);
+
+            const env = createVirtualEnvironment(window, {
+                distortionCallback,
+                liveTargetCallback() {
+                    return true;
+                },
+                protectDistortions: true,
+                globalObjectShape: window,
+            });
+
+            env.evaluate(`
+                expect(() => {
+                    delete ShadowRoot.prototype.host;
+                }).toThrowError(TypeError);
+            `);
+        });
+
+        it('should allow deleting properties that are not distorted', () => {
+            expect.assertions(2);
+
+            const env = createVirtualEnvironment(window, {
+                distortionCallback,
+                liveTargetCallback() {
+                    return true;
+                },
+                protectDistortions: true,
+                globalObjectShape: window,
+            });
+
+            env.evaluate(`
+                const obj = { x: 1 };
+                expect(delete obj.x).toBe(true);
+                expect(obj.x).toBe(undefined);
+            `);
+        });
+
+        it('should allow deleting an undistorted window API', () => {
+            expect.assertions(3);
+
+            const env = createVirtualEnvironment(window, {
+                distortionCallback,
+                liveTargetCallback() {
+                    return true;
+                },
+                protectDistortions: true,
+                globalObjectShape: window,
+            });
+
+            env.evaluate(`
+                expect(delete window.AbortController).toBe(true);
+                expect(window.AbortController).toBe(undefined);
+            `);
+
+            expect(window.AbortController).not.toBe(undefined);
+        });
+
+        it('should preserve the distorted getter after a failed delete attempt', () => {
+            expect.assertions(2);
+
+            const env = createVirtualEnvironment(window, {
+                distortionCallback,
+                liveTargetCallback() {
+                    return true;
+                },
+                protectDistortions: true,
+                globalObjectShape: window,
+            });
+
+            env.evaluate(`
+                const elm = document.createElement('div');
+                elm.attachShadow({ mode: 'open' });
+                expect(() => {
+                    delete ShadowRoot.prototype.host;
+                }).toThrowError(TypeError);
+                expect(elm.shadowRoot.host).toBe(null);
+            `);
+        });
+    });
+
+    describe('when disabled (default)', () => {
+        it('should not throw when deleting a property whose getter is distorted', () => {
+            expect.assertions(1);
+
+            const env = createVirtualEnvironment(window, {
+                distortionCallback,
+                liveTargetCallback() {
+                    return true;
+                },
+                globalObjectShape: window,
+            });
+
+            env.evaluate(`
+                expect(() => {
+                    delete ShadowRoot.prototype.host;
+                }).not.toThrow();
+            `);
+        });
+    });
+});


### PR DESCRIPTION
### Security Vulnerability Addressed

Because near-membrane proxies project blue-realm (host) objects into the red realm (sandbox) via `distortionCallback`, the integrity of distortions depends on the assumption that the sandbox cannot remove or replace the distorted property on the original target. Prior to this fix, untrusted code could exploit the `delete` operator to breach distortion boundaries:

1. **Distortion bypass via property deletion** — Sandbox code could `delete ShadowRoot.prototype.host` (or any property whose getter/setter/value is distorted). Because `callableDeleteProperty` on the blue side unconditionally called `ReflectDeleteProperty(target, key)`, the deletion succeeded on the real blue-realm object. Subsequent property accesses would either resolve to `undefined` or fall through to a prototype-chain definition that was not distorted, leaking the original blue-realm behavior.

### Technical Implementation

The fix adds a guard in `callableDeleteProperty` inside `createHooksCallback` (in `membrane.ts`). When the `protectDistortions` option is enabled, the callable retrieves the target property's descriptor via `ReflectGetOwnPropertyDescriptor`, extracts its `get`, `set`, and `value` components, and checks each against `distortionCallback`. If any component returns a value different from the original (indicating it has been distorted), the callable throws via `pushErrorAcrossBoundary(new TypeErrorCtor('Cannot delete property with a distortion.'))` before `ReflectDeleteProperty` is ever reached.

- **Option threading**: A new `protectDistortions?: boolean` option was added to `HooksOptions`, `VirtualEnvironmentOptions`, `BrowserEnvironmentOptions`, and `NodeEnvironmentOptions`. It flows from `createVirtualEnvironment` → `VirtualEnvironment` constructor → blue connector hooks options → `createHooksCallback` closure.
- **Error propagation**: The error is wrapped with `pushErrorAcrossBoundary` so it crosses the membrane correctly and surfaces as a `TypeError` inside the sandbox.
- **Feature gating**: The guard is gated behind `protectDistortions` (defaults to `false`), so existing consumers are unaffected.
- **Scope**: The guard runs in `callableDeleteProperty` on the blue side, which is called from the red side's `passthruDeletePropertyTrap` for live proxy targets. Static proxies do not cross the boundary for delete operations and are not covered by this guard.

### Test Coverage

Four tests in `test/distortions/protect-distortions.spec.js`:

| Test | What it validates |
|------|------------------|
| Throw on distorted getter delete | `delete ShadowRoot.prototype.host` throws `TypeError` when the getter is distorted and `protectDistortions: true` |
| Allow non-distorted delete | `delete obj.x` on a plain object succeeds normally |
| Preserve distortion after failed delete | After the throw, `elm.shadowRoot.host` still returns the distorted value (`null`) |
| No throw when disabled | Same delete succeeds silently when `protectDistortions` is not set |

Tests use `afterEach` to restore `ShadowRoot.prototype.host` via `Object.defineProperty` to prevent cross-test interference from the "when disabled" case which actually deletes the property.

### Security Implications

- **Before**: Sandbox code could delete any property on a blue-realm object, including those with distorted getters/setters/values, bypassing the distortion and leaking the original blue-realm definition.
- **After**: With `protectDistortions: true`, deletion of distorted properties throws a `TypeError`, preserving distortion integrity.
- The option defaults to `false` for backward compatibility and must be explicitly enabled by the consumer alongside `liveTargetCallback` (which ensures delete operations cross the boundary).