### PR TITLE
fix: @W-23623814 [266][LWS] Scope setPrototypeOf on live targets to the shadow target

### DIFF
--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -2474,7 +2474,20 @@ export function createMembraneMarshall(
                       this.defineProperty = BoundaryProxyHandler.passthruDefinePropertyTrap;
                       this.preventExtensions = BoundaryProxyHandler.passthruPreventExtensionsTrap;
                       this.set = BoundaryProxyHandler.passthruSetTrap;
-                      this.setPrototypeOf = BoundaryProxyHandler.passthruSetPrototypeOfTrap;
+                      // `[[SetPrototypeOf]]` is the one live trap we do not
+                      // passthru. The passthru variant calls `ReflectSetPrototypeOf`
+                      // on the RAW foreign target, which lets sandbox code splice a
+                      // foreign prototype (e.g. the primary-realm global) onto a live
+                      // target and then read foreign globals through inherited
+                      // lookups: live reads resolve against the RAW prototype chain
+                      // (`hybridGetTrap` -> `lookupForeignDescriptor`), never the
+                      // shadow target. It also lets sandbox code wipe a host-shared
+                      // object's prototype to `null`. Scoping the proto change to the
+                      // shadow target makes both observably inert while leaving
+                      // `set`/`defineProperty`/`deleteProperty` passthru (the
+                      // capabilities live targets actually need) untouched. No
+                      // legitimate live target re-parents itself across the membrane.
+                      this.setPrototypeOf = BoundaryProxyHandler.staticSetPrototypeOfTrap;
                   }
                 : noop;
 
@@ -3244,6 +3257,25 @@ export function createMembraneMarshall(
                         key === LOCKER_NEAR_MEMBRANE_SERIALIZED_VALUE_SYMBOL)
                 ) {
                     throw new TypeErrorCtor(ERR_ILLEGAL_PROPERTY_ACCESS);
+                }
+                // `x.__proto__ = value` triggers the `Object.prototype.__proto__`
+                // accessor, whose setter performs `[[SetPrototypeOf]]` on the
+                // target. This is the live target's `set` trap, and its passthru
+                // below would forward the write to the RAW foreign target,
+                // running the raw realm's `__proto__` setter and reparenting the
+                // raw object. That reintroduces the `setPrototypeOf` isolation
+                // leak (W-23623814) through property-assignment syntax: a
+                // subsequent inherited read would resolve foreign members
+                // against the spliced prototype. Confine an own `__proto__`
+                // write to the shadow target by delegating to `ReflectSet` on
+                // it, exactly as static proxies do via `staticSetTrap`; the red
+                // realm's own `__proto__` accessor then applies the correct
+                // ordinary semantics (primitive no-op, Object/Null reparent)
+                // scoped to the shadow target. A non-own write
+                // (`proxy !== receiver`) targets the other receiver, not the
+                // raw foreign target, so it is left to the passthru path.
+                if (IS_IN_SHADOW_REALM && key === '__proto__' && proxy === receiver) {
+                    return ReflectSet(shadowTarget, key, value, shadowTarget);
                 }
                 const isFastPath = proxy === receiver;
                 let result = false;

--- a/test/dom/live-object-set-prototype-of.spec.js
+++ b/test/dom/live-object-set-prototype-of.spec.js
@@ -1,0 +1,206 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+// W-23623814 in its originally reported form: a live DOM object (the reporter
+// used a CSSStyleDeclaration obtained via an element's `style`) whose prototype
+// is spliced from inside the sandbox to reach the primary-realm global. These
+// tests mark real DOM live objects with the `@@lockerLiveValue` marker (the
+// same mechanism locker uses in production) and confirm that no proto splice,
+// through any syntax, exposes foreign state or reparents the raw DOM object.
+//
+// Leak detection uses an endowed blue object carrying an OWN sentinel property
+// as the spliced prototype. That is the unambiguous signal: the sentinel is a
+// blue-realm own property, so it is only ever visible through inherited lookup
+// if the splice reached the raw target's prototype chain. (Splicing the sandbox
+// `globalThis` is a weaker probe here because the red realm's global does not
+// mirror blue-realm expandos, so a global read can read `undefined` for reasons
+// unrelated to the fix.) The companion
+// `test/membrane/set-prototype-of-isolation.spec.js` covers the same contract
+// with plain endowed live targets.
+
+const LOCKER_LIVE_VALUE_MARKER_SYMBOL = Symbol.for('@@lockerLiveValue');
+const SENTINEL_KEY = 'INHERITED_BLUE_SECRET';
+const SENTINEL_VALUE = 'blue-realm-only';
+
+function createLiveDomEnvironment(extraEndowments) {
+    return createVirtualEnvironment(window, {
+        endowments: Object.getOwnPropertyDescriptors(Object.assign({ expect }, extraEndowments)),
+        liveTargetCallback(target) {
+            return Object.hasOwn(target, LOCKER_LIVE_VALUE_MARKER_SYMBOL);
+        },
+    });
+}
+
+describe('@@lockerLiveValue setPrototypeOf isolation (DOM realm)', () => {
+    let created;
+
+    beforeEach(() => {
+        created = [];
+    });
+
+    afterEach(() => {
+        for (const node of created) {
+            node.remove();
+        }
+        created = [];
+    });
+
+    function appendMarkedDiv(id) {
+        const div = document.createElement('div');
+        div.id = id;
+        document.body.appendChild(div);
+        created.push(div);
+        // Mark the element's inline style declaration live, mirroring the
+        // reported CSSStyleDeclaration scenario.
+        Reflect.defineProperty(div.style, LOCKER_LIVE_VALUE_MARKER_SYMBOL, {});
+        return div;
+    }
+
+    it('does not leak a spliced blue prototype secret via Object.setPrototypeOf', () => {
+        expect.assertions(3);
+
+        const id = 'splice-payload-onto-style';
+        const div = appendMarkedDiv(id);
+        const originalStyleProto = Reflect.getPrototypeOf(div.style);
+        const bluePayload = { [SENTINEL_KEY]: SENTINEL_VALUE };
+        const env = createLiveDomEnvironment({ bluePayload });
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            // Reparent the live style declaration onto a blue object carrying a
+            // secret. If the change reached the raw style object, an inherited
+            // read would resolve the secret against the raw prototype chain.
+            Object.setPrototypeOf(style, bluePayload);
+            expect(style.${SENTINEL_KEY}).toBe(undefined);
+            expect(Object.getPrototypeOf(style)).not.toBe(bluePayload);
+        `);
+
+        // Host side: the raw style object's prototype is untouched.
+        expect(Reflect.getPrototypeOf(div.style)).toBe(originalStyleProto);
+    });
+
+    it('does not leak a spliced blue prototype secret via the __proto__ setter', () => {
+        expect.assertions(2);
+
+        const id = 'proto-setter-onto-style';
+        const div = appendMarkedDiv(id);
+        const originalStyleProto = Reflect.getPrototypeOf(div.style);
+        const bluePayload = { [SENTINEL_KEY]: SENTINEL_VALUE };
+        const env = createLiveDomEnvironment({ bluePayload });
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            // eslint-disable-next-line no-proto
+            style.__proto__ = bluePayload;
+            expect(style.${SENTINEL_KEY}).toBe(undefined);
+        `);
+
+        expect(Reflect.getPrototypeOf(div.style)).toBe(originalStyleProto);
+    });
+
+    it('does not reparent the raw style object when the sandbox global is spliced', () => {
+        expect.assertions(2);
+
+        const id = 'splice-global-onto-style';
+        const div = appendMarkedDiv(id);
+        const originalStyleProto = Reflect.getPrototypeOf(div.style);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            // The reported gadget: reparent the live style declaration onto the
+            // sandbox global. The observable, fix-relevant invariant is that the
+            // raw object is not reparented across the membrane.
+            Object.setPrototypeOf(style, globalThis);
+            expect(Object.getPrototypeOf(style)).not.toBe(globalThis);
+        `);
+
+        // Host side: the raw style object's prototype is unchanged, so it was
+        // never spliced onto the primary-realm global.
+        expect(Reflect.getPrototypeOf(div.style)).toBe(originalStyleProto);
+    });
+
+    it('keeps inline style writes flowing to the host after a splice attempt', () => {
+        expect.assertions(3);
+
+        const id = 'liveness-after-splice';
+        const div = appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            Object.setPrototypeOf(style, { color: 'green' });
+            // Liveness must be intact: the set trap still reaches the raw
+            // element, and the raw color accessor wins over the spliced proto.
+            style.color = 'red';
+            expect(style.color).toBe('red');
+        `);
+
+        expect(div.style.color).toBe('red');
+        expect(div.getAttribute('style')).toBe('color: red;');
+    });
+
+    it('does not degrade a live style declaration when its prototype is wiped to null', () => {
+        expect.assertions(3);
+
+        const id = 'null-wipe-style';
+        const div = appendMarkedDiv(id);
+        const originalStyleProto = Reflect.getPrototypeOf(div.style);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            Object.setPrototypeOf(style, null);
+            // The wipe is inert: the setProperty method inherited from the raw
+            // CSSStyleDeclaration prototype is still callable.
+            expect(typeof style.setProperty).toBe('function');
+            style.setProperty('color', 'blue');
+            expect(style.color).toBe('blue');
+        `);
+
+        expect(Reflect.getPrototypeOf(div.style)).toBe(originalStyleProto);
+    });
+
+    it('reports the raw prototype from getPrototypeOf after a splice attempt', () => {
+        expect.assertions(3);
+
+        const id = 'getproto-after-splice';
+        const div = appendMarkedDiv(id);
+        const originalStyleProto = Reflect.getPrototypeOf(div.style);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            const before = Object.getPrototypeOf(style);
+            Object.setPrototypeOf(style, { spliced: true });
+            const after = Object.getPrototypeOf(style);
+            // getPrototypeOf is passthru on live targets and reports the raw
+            // prototype, which is unchanged by the shadow-scoped splice.
+            expect(after).toBe(before);
+            expect(after.spliced).toBe(undefined);
+        `);
+
+        expect(Reflect.getPrototypeOf(div.style)).toBe(originalStyleProto);
+    });
+
+    it('does not leak a blue element expando spliced as a live target prototype', () => {
+        expect.assertions(2);
+
+        const id = 'element-proto-splice';
+        const div = appendMarkedDiv(id);
+        // Stash a blue-only expando on the raw element so a successful splice
+        // would surface it through inherited lookup.
+        div.BLUE_ELEMENT_EXPANDO = 'element-blue-only';
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const div = document.querySelector('#${id}');
+            const style = div.style;
+            // Splice the element (a foreign object) onto the live style. Its
+            // blue-only expando must not become inherited by the style.
+            Object.setPrototypeOf(style, div);
+            expect(style.BLUE_ELEMENT_EXPANDO).toBe(undefined);
+        `);
+
+        expect(div.BLUE_ELEMENT_EXPANDO).toBe('element-blue-only');
+    });
+});

--- a/test/membrane/object-branding.spec.js
+++ b/test/membrane/object-branding.spec.js
@@ -61,6 +61,17 @@ describe('object-branding', () => {
             endowments: Object.getOwnPropertyDescriptors({ expect }),
         });
 
+        // ArrayBufferView targets (DataView + typed arrays) are made live at
+        // proxy construction so the get trap can read buffer indices straight
+        // from the raw foreign target. Their `[[SetPrototypeOf]]` is scoped to
+        // the shadow target: a proto change from inside the sandbox is
+        // observably inert on the raw object. Branding therefore does NOT
+        // degrade to 'Object' for these targets when their proto is wiped to
+        // null, because the raw object's prototype (and its internal slots)
+        // are untouched. Plain foreign objects, including ArrayBuffer itself,
+        // remain static, so their proto wipe is observable and degrades the
+        // brand to 'Object' as before. This asymmetry is the observable
+        // consequence of the setPrototypeOf isolation fix (W-23623814).
         env.evaluate(`
             function getToStringTag(object) {
                 return Object.prototype.toString.call(object).slice(8, -1);
@@ -86,75 +97,80 @@ describe('object-branding', () => {
             expect(getToStringTag(setProto(new String('a'), null))).toBe('String');
             expect(getToStringTag(setProto(Object(Symbol('a')), null))).toBe('Object');
 
+            // ArrayBuffer is a plain (static) foreign object: proto wipe is
+            // observable and degrades the brand.
             const buffer = new ArrayBuffer(8);
             const bufferProto = Reflect.getPrototypeOf(buffer);
             expect(getToStringTag(setProto(buffer, null))).toBe('Object');
             expect(getToStringTag(setProto(buffer, bufferProto))).toBe('ArrayBuffer');
 
+            // ArrayBufferView targets below are live: the shadow-scoped proto
+            // change is inert, so the brand is preserved after a null wipe and
+            // a subsequent restore is a no-op that leaves the brand intact.
             const dataView = new DataView(buffer);
             const dataViewProto = Reflect.getPrototypeOf(dataView);
-            expect(getToStringTag(setProto(dataView, null))).toBe('Object');
+            expect(getToStringTag(setProto(dataView, null))).toBe('DataView');
             expect(getToStringTag(setProto(dataView, dataViewProto))).toBe('DataView');
 
             const float32Array = new Float32Array(buffer);
             const float32ArrayProto = Reflect.getPrototypeOf(float32Array);
-            expect(getToStringTag(setProto(float32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(float32Array, null))).toBe('Float32Array');
             expect(getToStringTag(setProto(float32Array, float32ArrayProto))).toBe(
                 'Float32Array'
             );
 
             const float64Array = new Float64Array(buffer);
             const float64ArrayProto = Reflect.getPrototypeOf(float64Array);
-            expect(getToStringTag(setProto(float64Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(float64Array, null))).toBe('Float64Array');
             expect(getToStringTag(setProto(float64Array, float64ArrayProto))).toBe(
                 'Float64Array'
             );
 
             const int8Array = new Int8Array(buffer);
             const int8ArrayProto = Reflect.getPrototypeOf(int8Array);
-            expect(getToStringTag(setProto(int8Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int8Array, null))).toBe('Int8Array');
             expect(getToStringTag(setProto(int8Array, int8ArrayProto))).toBe(
                 'Int8Array'
             );
 
             const int16Array = new Int16Array(buffer);
             const int16ArrayProto = Reflect.getPrototypeOf(int16Array);
-            expect(getToStringTag(setProto(int16Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int16Array, null))).toBe('Int16Array');
             expect(getToStringTag(setProto(int16Array, int8ArrayProto))).toBe(
                 'Int16Array'
             );
 
             const int32Array = new Int32Array(buffer);
             const int32ArrayProto = Reflect.getPrototypeOf(int32Array);
-            expect(getToStringTag(setProto(int32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(int32Array, null))).toBe('Int32Array');
             expect(getToStringTag(setProto(int32Array, int8ArrayProto))).toBe(
                 'Int32Array'
             );
 
             const uint8Array = new Uint8Array(buffer);
             const uint8ArrayProto = Reflect.getPrototypeOf(uint8Array);
-            expect(getToStringTag(setProto(uint8Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint8Array, null))).toBe('Uint8Array');
             expect(getToStringTag(setProto(uint8Array, uint8ArrayProto))).toBe(
                 'Uint8Array'
             );
 
             const uint8ClampedArray = new Uint8ClampedArray(buffer);
             const uint8ClampedArrayProto = Reflect.getPrototypeOf(uint8ClampedArray);
-            expect(getToStringTag(setProto(uint8ClampedArray, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint8ClampedArray, null))).toBe('Uint8ClampedArray');
             expect(getToStringTag(setProto(uint8ClampedArray, uint8ClampedArrayProto))).toBe(
                 'Uint8ClampedArray'
             );
 
             const uint16Array = new Uint16Array(buffer);
             const uint16ArrayProto = Reflect.getPrototypeOf(uint16Array);
-            expect(getToStringTag(setProto(uint16Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint16Array, null))).toBe('Uint16Array');
             expect(getToStringTag(setProto(uint16Array, uint16ArrayProto))).toBe(
                 'Uint16Array'
             );
 
             const uint32Array = new Uint32Array(buffer);
             const uint32ArrayProto = Reflect.getPrototypeOf(uint32Array);
-            expect(getToStringTag(setProto(uint32Array, null))).toBe('Object');
+            expect(getToStringTag(setProto(uint32Array, null))).toBe('Uint32Array');
             expect(getToStringTag(setProto(uint32Array, uint32ArrayProto))).toBe(
                 'Uint32Array'
             );

--- a/test/membrane/set-prototype-of-isolation.spec.js
+++ b/test/membrane/set-prototype-of-isolation.spec.js
@@ -1,0 +1,389 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+// W-23623814: `[[SetPrototypeOf]]` on a live target must be scoped to the
+// shadow target. A live proxy resolves reads against the RAW foreign target's
+// prototype chain, so if the trap reparented the RAW target the sandbox could
+// splice a foreign object (e.g. the primary-realm global) onto a live target
+// and read foreign members through inherited lookups. The fix routes the live
+// `setPrototypeOf` trap to `staticSetPrototypeOfTrap`, which applies the change
+// to the shadow target only. The observable contract is:
+//
+//   1. A splice from inside the sandbox is inert: inherited members of the
+//      spliced prototype are never visible through the live target, and the
+//      RAW target's prototype is unchanged.
+//   2. The other four live traps (set, defineProperty, deleteProperty,
+//      preventExtensions) remain passthru: live targets keep their mutability.
+//   3. Wiping a live target's prototype to null is inert, so a shared host
+//      object cannot be stripped of its methods from inside the sandbox.
+
+const LOCKER_LIVE_VALUE_MARKER_SYMBOL = Symbol.for('@@lockerLiveValue');
+
+function markLive(object) {
+    Reflect.defineProperty(object, LOCKER_LIVE_VALUE_MARKER_SYMBOL, {});
+    return object;
+}
+
+function createLiveEnvironment(extraEndowments) {
+    return createVirtualEnvironment(window, {
+        endowments: Object.getOwnPropertyDescriptors(Object.assign({ expect }, extraEndowments)),
+        liveTargetCallback(target) {
+            return Object.hasOwn(target, LOCKER_LIVE_VALUE_MARKER_SYMBOL);
+        },
+    });
+}
+
+describe('setPrototypeOf isolation on live targets', () => {
+    describe('the splice is inert (no foreign prototype leak)', () => {
+        it('does not leak spliced prototype members via Object.setPrototypeOf', () => {
+            expect.assertions(4);
+
+            const liveTarget = markLive({ own: 'own-value' });
+            const bluePayload = { INHERITED_SECRET: 'blue-only' };
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget, bluePayload });
+
+            env.evaluate(`
+                // Reparent the live target onto a foreign object carrying a
+                // sentinel. If the change reached the raw target, an inherited
+                // read would resolve the sentinel against the raw prototype
+                // chain (the W-23623814 escape). It must not.
+                Object.setPrototypeOf(liveTarget, bluePayload);
+                expect(liveTarget.own).toBe('own-value');
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            // Host side: the raw target's prototype is untouched.
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+            expect('INHERITED_SECRET' in liveTarget).toBe(false);
+        });
+
+        it('does not leak spliced prototype members via Reflect.setPrototypeOf', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const bluePayload = { INHERITED_SECRET: 'blue-only' };
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget, bluePayload });
+
+            env.evaluate(`
+                // Reflect returns true because the shadow target accepts the
+                // change, but the change stays on the shadow target.
+                const ok = Reflect.setPrototypeOf(liveTarget, bluePayload);
+                expect(ok).toBe(true);
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+
+        it('does not leak spliced prototype members via the __proto__ setter', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const bluePayload = { INHERITED_SECRET: 'blue-only' };
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget, bluePayload });
+
+            env.evaluate(`
+                // eslint-disable-next-line no-proto
+                liveTarget.__proto__ = bluePayload;
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+
+        it('does not expose foreign global members when the global is spliced as a prototype', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                // The exact reported gadget: splice the global object onto a
+                // live target, then read a global-only binding through
+                // inherited lookup. It would only resolve if the splice
+                // reached the raw prototype chain.
+                Object.setPrototypeOf(liveTarget, globalThis);
+                expect(liveTarget.Array).toBe(undefined);
+                expect(Object.getPrototypeOf(liveTarget)).not.toBe(globalThis);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+
+        it('remains inert across repeated splices and a restore attempt', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const bluePayload = { INHERITED_SECRET: 'blue-only' };
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget, bluePayload });
+
+            env.evaluate(`
+                Object.setPrototypeOf(liveTarget, bluePayload);
+                Object.setPrototypeOf(liveTarget, null);
+                Object.setPrototypeOf(liveTarget, bluePayload);
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+
+        it('does not leak when one live target is spliced onto another', () => {
+            expect.assertions(2);
+
+            const liveA = markLive({ fromA: 'a-value' });
+            const liveB = markLive({ fromB: 'b-value' });
+            const originalProtoB = Reflect.getPrototypeOf(liveB);
+            const env = createLiveEnvironment({ liveA, liveB });
+
+            env.evaluate(`
+                // Splicing a live target onto another live target must not
+                // make the donor's own members inherited by the recipient.
+                Object.setPrototypeOf(liveB, liveA);
+                expect(liveB.fromA).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveB)).toBe(originalProtoB);
+        });
+
+        it('is inert against a red-native indirection object that transitively inherits from a blue object', () => {
+            // This is the case a proto-argument identity check (e.g. "reject the
+            // splice only if the proto argument IS the blue document/global")
+            // would miss. The sandbox never passes the blue object directly.
+            // Instead it builds a RED-NATIVE object, sets ITS prototype to the
+            // blue object (an ordinary operation on a red-native object), then
+            // splices that indirection object onto the live target. An identity
+            // check comparing the proto argument to a known blue object would
+            // not match, so the splice would pass through and the live target
+            // would inherit the blue member transitively. The fix scopes ALL
+            // splices on live targets to the shadow target, so it is inert here
+            // regardless of what the proto argument transitively inherits from.
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const blueSecret = { INHERITED_SECRET: 'blue-only' };
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget, blueSecret });
+
+            env.evaluate(`
+                const indirection = {};
+                // Ordinary red-native splice: the indirection object now
+                // transitively inherits the blue secret. The sandbox can read
+                // it here because blueSecret is endowed; that is expected.
+                Object.setPrototypeOf(indirection, blueSecret);
+                expect(indirection.INHERITED_SECRET).toBe('blue-only');
+                // Splice the indirection object (NOT the blue object itself)
+                // onto the live target. An identity check on the proto argument
+                // would let this through; the shadow-scoped fix does not.
+                Object.setPrototypeOf(liveTarget, indirection);
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+
+        it('positive control: the same splice IS visible on a red-native object', () => {
+            // This test proves the inertness assertions above are meaningful and
+            // not vacuous. A prototype splice from inside the sandbox onto an
+            // object the sandbox itself created (a red-native object) DOES take
+            // effect and DOES expose inherited members. The security property is
+            // that the same operation is inert only when the target is a live
+            // host object crossing the membrane. If this control ever fails, the
+            // inertness tests are no longer testing containment.
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const originalProto = Reflect.getPrototypeOf(liveTarget);
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                const redProto = { INHERITED_SECRET: 'red-native' };
+                const redObject = {};
+                // On a red-native object the splice is a normal ordinary
+                // operation: the inherited member resolves.
+                Object.setPrototypeOf(redObject, redProto);
+                expect(redObject.INHERITED_SECRET).toBe('red-native');
+                // On the live host target the identical operation is inert.
+                Object.setPrototypeOf(liveTarget, redProto);
+                expect(liveTarget.INHERITED_SECRET).toBe(undefined);
+            `);
+
+            expect(Reflect.getPrototypeOf(liveTarget)).toBe(originalProto);
+        });
+    });
+
+    describe('the other live traps stay passthru', () => {
+        it('preserves set, defineProperty, and deleteProperty after a splice attempt', () => {
+            expect.assertions(6);
+
+            const liveTarget = markLive({ removable: 'gone-soon' });
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.setPrototypeOf(liveTarget, { poison: 1 });
+                // The remaining live traps must still reach the raw shared target.
+                liveTarget.added = 'via-set';
+                Object.defineProperty(liveTarget, 'defined', {
+                    value: 'via-define',
+                    enumerable: true,
+                    configurable: true,
+                });
+                delete liveTarget.removable;
+                expect(liveTarget.added).toBe('via-set');
+                expect(liveTarget.defined).toBe('via-define');
+                expect('removable' in liveTarget).toBe(false);
+            `);
+
+            // Host observes every mutation on the raw target.
+            expect(liveTarget.added).toBe('via-set');
+            expect(liveTarget.defined).toBe('via-define');
+            expect('removable' in liveTarget).toBe(false);
+        });
+
+        it('keeps element.style-like live writes flowing to the host after a splice attempt', () => {
+            expect.assertions(3);
+
+            const backing = { color: '' };
+            const liveStyle = markLive({});
+            Object.defineProperty(liveStyle, 'color', {
+                get() {
+                    return backing.color;
+                },
+                set(value) {
+                    backing.color = value;
+                },
+                enumerable: true,
+                configurable: true,
+            });
+            const env = createLiveEnvironment({ liveStyle });
+
+            env.evaluate(`
+                Object.setPrototypeOf(liveStyle, { color: 'green' });
+                // The accessor on the raw target must still win: this write
+                // flows through the live set trap to the host backing store.
+                liveStyle.color = 'red';
+                expect(liveStyle.color).toBe('red');
+            `);
+
+            expect(backing.color).toBe('red');
+            expect(liveStyle.color).toBe('red');
+        });
+    });
+
+    describe('prototype wipe to null is inert (DoS closed)', () => {
+        it('keeps a live target usable after an attempt to wipe its prototype to null', () => {
+            expect.assertions(4);
+
+            class Widget {
+                constructor() {
+                    this.label = 'rendered';
+                }
+
+                render() {
+                    return this.label;
+                }
+            }
+            const liveWidget = markLive(new Widget());
+            const env = createLiveEnvironment({ liveWidget });
+
+            env.evaluate(`
+                // A live target is shared with the host. Wiping its prototype
+                // from inside the sandbox must not strip the host's methods.
+                Object.setPrototypeOf(liveWidget, null);
+                expect(typeof liveWidget.render).toBe('function');
+                expect(liveWidget.render()).toBe('rendered');
+            `);
+
+            expect(Reflect.getPrototypeOf(liveWidget)).not.toBe(null);
+            expect(liveWidget.render()).toBe('rendered');
+        });
+    });
+});
+
+describe('setPrototypeOf on structurally-live foreign arrays and typed arrays', () => {
+    it('preserves index reads and writes on a foreign array after a splice attempt', () => {
+        expect.assertions(6);
+
+        const blueArray = [10, 20, 30];
+        const env = createLiveEnvironment({ blueArray });
+
+        env.evaluate(`
+            expect(blueArray[0]).toBe(10);
+            Object.setPrototypeOf(blueArray, { poison: 1 });
+            expect(blueArray[1]).toBe(20);
+            expect(blueArray.poison).toBe(undefined);
+            blueArray[0] = 99;
+            expect(blueArray[0]).toBe(99);
+        `);
+
+        expect(blueArray[0]).toBe(99);
+        expect(Reflect.getPrototypeOf(blueArray)).toBe(Array.prototype);
+    });
+
+    it('preserves typed array index access and cached length after a splice attempt', () => {
+        expect.assertions(7);
+
+        const blueU8 = new Uint8Array([1, 2, 3, 4]);
+        const env = createLiveEnvironment({ blueU8 });
+
+        env.evaluate(`
+            expect(blueU8[0]).toBe(1);
+            expect(blueU8.length).toBe(4);
+            // The typed-array get fast path reads indices from the buffer using
+            // a construction-time cached length; splicing a { length: 0 }
+            // prototype must not shadow that.
+            Object.setPrototypeOf(blueU8, { length: 0 });
+            expect(blueU8[2]).toBe(3);
+            expect(blueU8.length).toBe(4);
+            blueU8[0] = 42;
+            expect(blueU8[0]).toBe(42);
+        `);
+
+        expect(blueU8[0]).toBe(42);
+        expect(Reflect.getPrototypeOf(blueU8)).toBe(Uint8Array.prototype);
+    });
+
+    it('preserves branding of a foreign typed array after a null prototype wipe', () => {
+        expect.assertions(3);
+
+        const blueU8 = new Uint8Array([5, 6, 7]);
+        const env = createLiveEnvironment({ blueU8 });
+
+        env.evaluate(`
+            const tag = (o) => Object.prototype.toString.call(o).slice(8, -1);
+            expect(tag(blueU8)).toBe('Uint8Array');
+            Reflect.setPrototypeOf(blueU8, null);
+            // The wipe is inert on the live target, so branding is preserved.
+            expect(tag(blueU8)).toBe('Uint8Array');
+        `);
+
+        expect(Object.prototype.toString.call(blueU8).slice(8, -1)).toBe('Uint8Array');
+    });
+});
+
+describe('setPrototypeOf on plain (static) foreign objects is unaffected by the fix', () => {
+    it('keeps a static proto splice scoped to the shadow target', () => {
+        expect.assertions(4);
+
+        const staticObj = { own: 1 };
+        const originalProto = Reflect.getPrototypeOf(staticObj);
+        const env = createVirtualEnvironment(window, {
+            endowments: Object.getOwnPropertyDescriptors({ expect, staticObj }),
+        });
+
+        env.evaluate(`
+            Object.setPrototypeOf(staticObj, { poison: 1 });
+            // For a static proxy the change lands on the shadow target, so the
+            // sandbox observes it locally.
+            expect(Object.getPrototypeOf(staticObj).poison).toBe(1);
+            expect(staticObj.poison).toBe(1);
+        `);
+
+        // The raw host object is untouched.
+        expect(Reflect.getPrototypeOf(staticObj)).toBe(originalProto);
+        expect('poison' in staticObj).toBe(false);
+    });
+});


### PR DESCRIPTION
A live BoundaryProxyHandler installed the passthru [[SetPrototypeOf]] trap via makeProxyLive(), which reparents the RAW foreign target. Sandbox code could splice a foreign prototype (e.g. the primary-realm global) onto a live target (getComputedStyle result, element.style, dataset, Storage, or any @@lockerLiveValue-tagged object such as a LightningElement instance) and then read foreign globals through inherited lookups, since live reads resolve against the RAW prototype chain. It could also wipe a host-shared object's prototype to null. Route the live setPrototypeOf trap to staticSetPrototypeOfTrap so the proto change is scoped to the inert shadow target, making both observably inert while leaving set/defineProperty/deleteProperty passthru (the capabilities live targets actually need) untouched.

Also close the property-assignment form of the same leak: x.__proto__ = value routes through the live set trap, whose passthru would run the raw realm's __proto__ accessor on the foreign target. Confine an own __proto__ write to the shadow target, mirroring staticSetTrap.

Tests: setPrototypeOf isolation on live targets (membrane + DOM realm, incl. transitive-inheritance and positive-control cases) and updated object-branding null-proto expectations for structurally-live ArrayBufferView targets.