### PR TITLE
fix: @W-23552746 [266][LWS] Scope defineProperty accessors on live targets to the shadow target

### DIFF
--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -2471,9 +2471,23 @@ export function createMembraneMarshall(
                       // Replace pending traps with live traps that can work with the
                       // target without taking snapshots.
                       this.deleteProperty = BoundaryProxyHandler.passthruDeletePropertyTrap;
-                      this.defineProperty = BoundaryProxyHandler.passthruDefinePropertyTrap;
                       this.preventExtensions = BoundaryProxyHandler.passthruPreventExtensionsTrap;
                       this.set = BoundaryProxyHandler.passthruSetTrap;
+                      // `[[DefineOwnProperty]]` is passthru for DATA descriptors
+                      // (the expando capability live targets actually need) but
+                      // accessor descriptors are scoped to the shadow target. The
+                      // passthru variant calls `foreignCallableDefineProperty` on the
+                      // RAW foreign target; for an accessor that plants a
+                      // sandbox-authored getter/setter directly onto a host-shared
+                      // object. Because the descriptor's functions are marshalled as
+                      // pointers back into the sandbox, any later access from the
+                      // primary realm (a confused deputy reading the planted key)
+                      // would execute sandbox code with the RAW object as `this` and
+                      // read raw-global-only state through it. Data expandos carry no
+                      // such callback, so they remain passthru; only accessors are
+                      // contained. See `liveAccessorGuardedDefinePropertyTrap`.
+                      this.defineProperty =
+                          BoundaryProxyHandler.liveAccessorGuardedDefinePropertyTrap;
                       // `[[SetPrototypeOf]]` is the one live trap we do not
                       // passthru. The passthru variant calls `ReflectSetPrototypeOf`
                       // on the RAW foreign target, which lets sandbox code splice a
@@ -2484,9 +2498,9 @@ export function createMembraneMarshall(
                       // shadow target. It also lets sandbox code wipe a host-shared
                       // object's prototype to `null`. Scoping the proto change to the
                       // shadow target makes both observably inert while leaving
-                      // `set`/`defineProperty`/`deleteProperty` passthru (the
-                      // capabilities live targets actually need) untouched. No
-                      // legitimate live target re-parents itself across the membrane.
+                      // `set`/`deleteProperty` passthru (the capabilities live targets
+                      // actually need) untouched. No legitimate live target re-parents
+                      // itself across the membrane.
                       this.setPrototypeOf = BoundaryProxyHandler.staticSetPrototypeOfTrap;
                   }
                 : noop;
@@ -2932,6 +2946,87 @@ export function createMembraneMarshall(
                 }
                 return result;
             }
+
+            // `[[DefineOwnProperty]]` trap for LIVE targets. Data descriptors are the
+            // expando capability live targets rely on and stay passthru to the RAW
+            // foreign target via `passthruDefinePropertyTrap`. Accessor descriptors
+            // (a `get` and/or `set`), however, would install sandbox-authored
+            // functions onto a host-shared object; a subsequent access from the
+            // primary realm would run that sandbox code with the RAW target as
+            // receiver and expose raw-global-only state. We contain accessors on the
+            // inert shadow target instead. This mirrors the `staticSetPrototypeOfTrap`
+            // contract: the operation is observably inert from every side. A live
+            // `get` resolves against the RAW foreign target (`lookupForeignDescriptor`
+            // reads the raw own descriptor and walks the RAW prototype chain; it only
+            // ever writes the shadow target, never reads its own properties), so the
+            // sandbox reads back `undefined` for a shadow-scoped accessor too. The
+            // security-relevant guarantee is that no sandbox-authored callback ever
+            // reaches the raw host-shared object.
+            //
+            // The shadow-scoped copy is always written with `configurable: true`,
+            // regardless of what the sandbox asked for. A live proxy's `has`,
+            // `ownKeys`, and `getOwnPropertyDescriptor` traps are NOT overridden by
+            // `makeProxyLive()` (see `hybridHasTrap`, `passthruOwnKeysTrap`,
+            // `passthruGetOwnPropertyDescriptorTrap`): they all resolve against the
+            // RAW foreign target and never consult the shadow target's own
+            // properties. `Object.defineProperty` defaults `configurable` to
+            // `false`, so the common `{ get() {...} }` shape would otherwise leave
+            // the shadow target — the proxy's actual `[[ProxyTarget]]` — holding a
+            // NON-CONFIGURABLE own key that those raw-resolving traps can never
+            // mirror. The engine's proxy invariants then throw on the very next
+            // `has`/`ownKeys`/`getOwnPropertyDescriptor` (`in`, `Object.keys`,
+            // spread, `JSON.stringify`, `Object.getOwnPropertyDescriptor`, ...)
+            // because a non-configurable target key must be reported by those traps
+            // and it never can be. Since the accessor is invisible through the
+            // proxy either way (reads resolve against the raw target), forcing
+            // `configurable: true` is not observable to the sandbox, and it keeps
+            // every read-side invariant satisfiable. An explicit `configurable:
+            // false` request cannot be honored while preserving that invisibility;
+            // it now fails fast with a native TypeError raised by the engine's own
+            // `defineProperty` trap-result invariant check (requested
+            // non-configurable vs. an actually-configurable target descriptor) at
+            // the `defineProperty` call site itself, rather than deferring the
+            // detonation to a later, unrelated read.
+            private static liveAccessorGuardedDefinePropertyTrap = IS_IN_SHADOW_REALM
+                ? function (
+                      this: BoundaryProxyHandler,
+                      shadowTarget: ShadowTarget,
+                      key: PropertyKey,
+                      unsafePartialDesc: PropertyDescriptor
+                  ): ReturnType<typeof Reflect.defineProperty> {
+                      // A descriptor is an accessor iff it carries a `get` or `set`.
+                      // Read membership before detaching the prototype so a poisoned
+                      // `Object.prototype` getter cannot forge the answer.
+                      const isAccessorDescriptor =
+                          'get' in unsafePartialDesc || 'set' in unsafePartialDesc;
+                      if (isAccessorDescriptor) {
+                          lastProxyTrapCalled = ProxyHandlerTraps.DefineProperty;
+                          // Build a fresh descriptor rather than writing the
+                          // sandbox's `unsafePartialDesc` object directly, and
+                          // force `configurable: true` on the shadow-scoped copy
+                          // (see the block comment above).
+                          const shadowDesc = { __proto__: null } as PropertyDescriptor;
+                          if ('get' in unsafePartialDesc) {
+                              shadowDesc.get = unsafePartialDesc.get;
+                          }
+                          if ('set' in unsafePartialDesc) {
+                              shadowDesc.set = unsafePartialDesc.set;
+                          }
+                          if ('enumerable' in unsafePartialDesc) {
+                              shadowDesc.enumerable = unsafePartialDesc.enumerable;
+                          }
+                          shadowDesc.configurable = true;
+                          // Scope the accessor to the shadow target: observably
+                          // defined for the sandbox, never planted on the raw object.
+                          return ReflectDefineProperty(shadowTarget, key, shadowDesc);
+                      }
+                      return ReflectApply(BoundaryProxyHandler.passthruDefinePropertyTrap, this, [
+                          shadowTarget,
+                          key,
+                          unsafePartialDesc,
+                      ]);
+                  }
+                : (alwaysFalse as typeof Reflect.defineProperty);
 
             private static passthruDeletePropertyTrap(
                 this: BoundaryProxyHandler,

--- a/test/dom/live-object-define-property-accessor.spec.js
+++ b/test/dom/live-object-define-property-accessor.spec.js
@@ -1,0 +1,188 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+// W-23552746 in its DOM form: a live DOM object (here a CSSStyleDeclaration
+// obtained via an element's `style`, the same live producer the reporter used
+// for the setPrototypeOf variant) onto which the sandbox defines an ACCESSOR
+// property. A live target's `defineProperty` trap is otherwise passthru, so the
+// accessor would be planted on the RAW style object; a later access from the
+// primary realm would run the sandbox getter/setter with the RAW object as
+// receiver. These tests mark real DOM live objects with the `@@lockerLiveValue`
+// marker (the mechanism locker uses in production) and confirm the accessor is
+// contained on the shadow target, while data expandos still pass through. The
+// companion `test/membrane/define-property-accessor-isolation.spec.js` covers
+// the same contract with plain endowed live targets.
+
+const LOCKER_LIVE_VALUE_MARKER_SYMBOL = Symbol.for('@@lockerLiveValue');
+
+function createLiveDomEnvironment(extraEndowments) {
+    return createVirtualEnvironment(window, {
+        endowments: Object.getOwnPropertyDescriptors(Object.assign({ expect }, extraEndowments)),
+        liveTargetCallback(target) {
+            return Object.hasOwn(target, LOCKER_LIVE_VALUE_MARKER_SYMBOL);
+        },
+    });
+}
+
+describe('@@lockerLiveValue defineProperty accessor isolation (DOM realm)', () => {
+    let created;
+
+    beforeEach(() => {
+        created = [];
+    });
+
+    afterEach(() => {
+        for (const node of created) {
+            node.remove();
+        }
+        created = [];
+    });
+
+    function appendMarkedDiv(id) {
+        const div = document.createElement('div');
+        div.id = id;
+        document.body.appendChild(div);
+        created.push(div);
+        // Mark the element's inline style declaration live, mirroring the
+        // reported CSSStyleDeclaration scenario.
+        Reflect.defineProperty(div.style, LOCKER_LIVE_VALUE_MARKER_SYMBOL, {});
+        return div;
+    }
+
+    it('does not plant a sandbox getter on the raw style object via Object.defineProperty', () => {
+        expect.assertions(3);
+
+        const id = 'accessor-onto-style';
+        const div = appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            let ran = false;
+            Object.defineProperty(style, 'pwned', {
+                configurable: true,
+                get() {
+                    ran = true;
+                    return 'SANDBOX_GETTER';
+                },
+            });
+            // A live get resolves against the raw style object, which never
+            // gained the accessor, so the sandbox reads back undefined.
+            expect(style.pwned).toBe(undefined);
+            expect(ran).toBe(false);
+        `);
+
+        // Host side: the raw style object has no such accessor, so a read from
+        // the primary realm runs no sandbox code.
+        expect(Reflect.getOwnPropertyDescriptor(div.style, 'pwned')).toBe(undefined);
+    });
+
+    it('keeps inline style writes flowing to the host after an accessor is contained', () => {
+        expect.assertions(3);
+
+        const id = 'liveness-after-accessor';
+        const div = appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            Object.defineProperty(style, 'pwned', {
+                configurable: true,
+                get() {
+                    return 'contained';
+                },
+            });
+            // Liveness must be intact: the set trap still reaches the raw
+            // element, and the raw color accessor still wins.
+            style.color = 'red';
+            expect(style.color).toBe('red');
+            expect(style.pwned).toBe(undefined);
+        `);
+
+        expect(div.style.color).toBe('red');
+    });
+
+    it('passes a data expando through to the raw style object via Object.defineProperty', () => {
+        expect.assertions(2);
+
+        const id = 'data-expando-onto-style';
+        const div = appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            // A data descriptor is passthru: the expando lands on the raw style
+            // object (the capability live targets rely on).
+            Object.defineProperty(style, 'dataExpando', {
+                configurable: true,
+                writable: true,
+                value: 'DATA_VALUE',
+            });
+            expect(style.dataExpando).toBe('DATA_VALUE');
+        `);
+
+        expect(div.style.dataExpando).toBe('DATA_VALUE');
+    });
+
+    it('does not break has/ownKeys/getOwnPropertyDescriptor invariants for a default (no explicit configurable) accessor', () => {
+        // `Object.defineProperty` defaults `configurable` to `false`. See the
+        // companion `test/membrane/define-property-accessor-isolation.spec.js`
+        // for the full invariant explanation: the shadow-scoped copy must be
+        // forced to `configurable: true` or the live `has`/`ownKeys`/
+        // `getOwnPropertyDescriptor` traps (which resolve against the RAW style
+        // object, not the shadow target) could never mirror a non-configurable
+        // own key on the shadow target and every subsequent lookup would throw.
+        expect.assertions(4);
+
+        const id = 'default-accessor-onto-style';
+        appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            let ran = false;
+            Object.defineProperty(style, 'pwned', {
+                get() {
+                    ran = true;
+                    return 'leak';
+                },
+            });
+            expect(() => 'pwned' in style).not.toThrow();
+            expect('pwned' in style).toBe(false);
+            expect(() => Object.getOwnPropertyDescriptor(style, 'pwned')).not.toThrow();
+            expect(Object.getOwnPropertyDescriptor(style, 'pwned')).toBe(undefined);
+        `);
+    });
+
+    it('fails fast with a native TypeError for an explicit configurable: false accessor', () => {
+        // The shadow-scoped copy is forced to `configurable: true`, so an
+        // explicit `configurable: false` request cannot be honored while
+        // keeping the accessor invisible through the proxy. The engine's own
+        // `defineProperty` trap-result invariant check rejects the mismatch
+        // synchronously at the call site, rather than deferring the detonation
+        // to a later read.
+        expect.assertions(2);
+
+        const id = 'non-configurable-accessor-onto-style';
+        appendMarkedDiv(id);
+        const env = createLiveDomEnvironment();
+
+        env.evaluate(`
+            const style = document.querySelector('#${id}').style;
+            let threw = false;
+            let isTypeError = false;
+            try {
+                Object.defineProperty(style, 'pwned', {
+                    configurable: false,
+                    get() {
+                        return 'leak';
+                    },
+                });
+            } catch (e) {
+                threw = true;
+                isTypeError = e instanceof TypeError;
+            }
+            expect(threw).toBe(true);
+            expect(isTypeError).toBe(true);
+        `);
+    });
+});

--- a/test/membrane/define-property-accessor-isolation.spec.js
+++ b/test/membrane/define-property-accessor-isolation.spec.js
@@ -1,0 +1,551 @@
+import createVirtualEnvironment from '@locker/near-membrane-dom';
+
+// W-23552746: `[[DefineOwnProperty]]` of an ACCESSOR descriptor on a live target
+// must be scoped to the shadow target. A live proxy's `defineProperty` trap is
+// otherwise passthru, so an accessor defined from inside the sandbox would plant
+// a sandbox-authored getter/setter directly onto the RAW host-shared object.
+// Because those functions are marshalled as pointers back into the sandbox, a
+// later access from the primary realm (a confused deputy reading the planted
+// key) would execute sandbox code with the RAW object as receiver and read
+// raw-global-only state through it. The fix routes accessor descriptors on live
+// targets to the shadow target only. The observable contract mirrors the
+// `setPrototypeOf` fix (W-23623814):
+//
+//   1. An accessor defined from inside the sandbox is inert: the RAW target
+//      never gains the getter/setter, and — because a live `get` resolves
+//      against the RAW target — the sandbox reads back `undefined` too.
+//   2. DATA descriptors remain passthru: an expando defined from the sandbox
+//      still flows to the RAW target (the capability live targets need).
+//   3. The other live traps (set, deleteProperty, preventExtensions) and
+//      indexed writes are untouched: live targets keep their mutability.
+
+const LOCKER_LIVE_VALUE_MARKER_SYMBOL = Symbol.for('@@lockerLiveValue');
+
+function markLive(object) {
+    Reflect.defineProperty(object, LOCKER_LIVE_VALUE_MARKER_SYMBOL, {});
+    return object;
+}
+
+function createLiveEnvironment(extraEndowments) {
+    return createVirtualEnvironment(window, {
+        endowments: Object.getOwnPropertyDescriptors(Object.assign({ expect }, extraEndowments)),
+        liveTargetCallback(target) {
+            return Object.hasOwn(target, LOCKER_LIVE_VALUE_MARKER_SYMBOL);
+        },
+    });
+}
+
+describe('defineProperty accessor isolation on live targets', () => {
+    describe('the accessor is scoped to the shadow target (no callback on the raw object)', () => {
+        it('does not plant a getter on the raw target via Object.defineProperty', () => {
+            expect.assertions(4);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let getterRan = false;
+                // Define an accessor on the live target. defineProperty returns
+                // true because the shadow target accepts it, but the accessor is
+                // contained there.
+                const ok = Object.defineProperty(liveTarget, 'pwned', {
+                    configurable: true,
+                    get() {
+                        getterRan = true;
+                        return 'SANDBOX_GETTER';
+                    },
+                });
+                expect(ok).toBe(liveTarget);
+                // A live get resolves against the RAW target, which never gained
+                // the accessor, so the sandbox reads back undefined and the
+                // getter never runs.
+                expect(liveTarget.pwned).toBe(undefined);
+                expect(getterRan).toBe(false);
+            `);
+
+            // Host side: the raw target never gained the accessor, so a read
+            // from the primary realm executes no sandbox code.
+            const rawDesc = Reflect.getOwnPropertyDescriptor(liveTarget, 'pwned');
+            expect(rawDesc).toBe(undefined);
+        });
+
+        it('does not plant a setter on the raw target via Reflect.defineProperty', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let setterRan = false;
+                const ok = Reflect.defineProperty(liveTarget, 'sink', {
+                    configurable: true,
+                    set(value) {
+                        setterRan = true;
+                    },
+                });
+                expect(ok).toBe(true);
+                // Writing the key from the sandbox routes through the live set
+                // trap to the raw target; the shadow-scoped setter never runs.
+                liveTarget.sink = 'ignored';
+                expect(setterRan).toBe(false);
+            `);
+
+            const rawDesc = Reflect.getOwnPropertyDescriptor(liveTarget, 'sink');
+            expect(rawDesc && rawDesc.set).toBe(undefined);
+        });
+
+        it('does not run a sandbox getter when the host reads the planted key (confused deputy)', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'stolen', {
+                    configurable: true,
+                    get() {
+                        // If this ever runs on the host with the raw receiver,
+                        // it would be the confused deputy. It must never run
+                        // outside the sandbox.
+                        return 'SANDBOX_CODE_RAN_ON_HOST';
+                    },
+                });
+                expect(liveTarget.stolen).toBe(undefined);
+            `);
+
+            // Host reads the planted key. No sandbox getter exists on the raw
+            // object, so this is inert and never returns the sandbox sentinel.
+            expect(liveTarget.stolen).not.toBe('SANDBOX_CODE_RAN_ON_HOST');
+        });
+
+        it('is inert regardless of whether the descriptor also carries configurable/enumerable', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let ran = false;
+                // A full accessor descriptor (get + enumerable + configurable):
+                // still an accessor, still contained.
+                Object.defineProperty(liveTarget, 'full', {
+                    configurable: true,
+                    enumerable: true,
+                    get() {
+                        ran = true;
+                        return 1;
+                    },
+                });
+                expect(liveTarget.full).toBe(undefined);
+                expect(ran).toBe(false);
+            `);
+
+            expect(Reflect.getOwnPropertyDescriptor(liveTarget, 'full')).toBe(undefined);
+        });
+    });
+
+    describe('default (no explicit configurable) accessor descriptors do not break read-side proxy invariants', () => {
+        // `Object.defineProperty` defaults `configurable` to `false` when the
+        // descriptor omits it, which is the common `{ get() {...} }` shape. The
+        // shadow-scoped copy must still be written with `configurable: true`
+        // (see the block comment above `liveAccessorGuardedDefinePropertyTrap`):
+        // a live proxy's `has`, `ownKeys`, and `getOwnPropertyDescriptor` traps
+        // are NOT overridden by `makeProxyLive()` and always resolve against the
+        // RAW foreign target, so a non-configurable OWN key on the shadow target
+        // (the proxy's actual `[[ProxyTarget]]`) would be impossible for those
+        // traps to mirror and every subsequent enumeration/lookup would throw a
+        // native proxy-invariant `TypeError`. Forcing `configurable: true` is not
+        // observable to the sandbox because the accessor is invisible through
+        // the proxy either way (reads resolve against the raw target).
+        it('Object.keys does not throw and omits the contained key', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({ own: 1 });
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'k', {
+                    get() {
+                        return 'leak';
+                    },
+                });
+                expect(Object.keys(liveTarget)).toEqual(['own']);
+            `);
+
+            expect(Object.keys(liveTarget)).toEqual(['own']);
+        });
+
+        it("'in' does not throw and reports the contained key as absent", () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'k', {
+                    get() {
+                        return 'leak';
+                    },
+                });
+                expect('k' in liveTarget).toBe(false);
+            `);
+
+            expect('k' in liveTarget).toBe(false);
+        });
+
+        it('object spread does not throw and omits the contained key', () => {
+            expect.assertions(1);
+
+            const liveTarget = markLive({ own: 1 });
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'k', {
+                    get() {
+                        return 'leak';
+                    },
+                });
+                const copy = { ...liveTarget };
+                expect(copy).toEqual({ own: 1 });
+            `);
+        });
+
+        it('JSON.stringify does not throw and omits the contained key', () => {
+            expect.assertions(1);
+
+            const liveTarget = markLive({ own: 1 });
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'k', {
+                    get() {
+                        return 'leak';
+                    },
+                });
+                expect(JSON.stringify(liveTarget)).toBe('{"own":1}');
+            `);
+        });
+
+        it('Object.getOwnPropertyDescriptor does not throw and reports undefined', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'k', {
+                    get() {
+                        return 'leak';
+                    },
+                });
+                expect(Object.getOwnPropertyDescriptor(liveTarget, 'k')).toBe(undefined);
+            `);
+
+            expect(Reflect.getOwnPropertyDescriptor(liveTarget, 'k')).toBe(undefined);
+        });
+
+        it('handles a default descriptor with a set only the same way', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let setterRan = false;
+                Object.defineProperty(liveTarget, 'sink', {
+                    set() {
+                        setterRan = true;
+                    },
+                });
+                expect(() => Object.keys(liveTarget)).not.toThrow();
+                expect('sink' in liveTarget).toBe(false);
+            `);
+
+            expect(Reflect.getOwnPropertyDescriptor(liveTarget, 'sink')).toBe(undefined);
+        });
+
+        it('the security property holds: the raw target never gains the accessor and a host read runs no sandbox code', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'stolen', {
+                    get() {
+                        // Must never run on the host with the raw receiver.
+                        return 'SANDBOX_CODE_RAN_ON_HOST';
+                    },
+                });
+                expect(liveTarget.stolen).toBe(undefined);
+            `);
+
+            expect(Reflect.getOwnPropertyDescriptor(liveTarget, 'stolen')).toBe(undefined);
+            expect(liveTarget.stolen).not.toBe('SANDBOX_CODE_RAN_ON_HOST');
+        });
+    });
+
+    describe('an explicit configurable: false accessor descriptor fails fast at the defineProperty call', () => {
+        // Forcing the shadow-scoped copy to `configurable: true` (see above)
+        // keeps the default shape fully clean, but it means an explicit
+        // `configurable: false` request cannot be honored while also keeping
+        // the accessor invisible through the proxy: the engine's own
+        // `defineProperty` trap-result invariant check compares the SANDBOX'S
+        // requested descriptor (non-configurable) against the resulting target
+        // descriptor (configurable, because we forced it) and rejects the
+        // mismatch. The result is a native `TypeError` thrown synchronously at
+        // the `Object.defineProperty`/`Reflect.defineProperty` call site inside
+        // the sandbox — fail-fast, rather than deferring the detonation to a
+        // later, unrelated read as the unguarded shape used to. This is the
+        // documented, intentional behavior for this shape: you cannot install a
+        // non-configurable accessor that stays off the raw object while keeping
+        // the live read traps consistent.
+        it('Object.defineProperty throws synchronously and never reaches the raw target', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let threw = false;
+                let isTypeError = false;
+                try {
+                    Object.defineProperty(liveTarget, 'k', {
+                        configurable: false,
+                        get() {
+                            return 'leak';
+                        },
+                    });
+                } catch (e) {
+                    threw = true;
+                    isTypeError = e instanceof TypeError;
+                }
+                expect(threw).toBe(true);
+                expect(isTypeError).toBe(true);
+            `);
+        });
+
+        it('Reflect.defineProperty throws synchronously for the same shape', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let threw = false;
+                let isTypeError = false;
+                try {
+                    Reflect.defineProperty(liveTarget, 'k', {
+                        configurable: false,
+                        set() {},
+                    });
+                } catch (e) {
+                    threw = true;
+                    isTypeError = e instanceof TypeError;
+                }
+                expect(threw).toBe(true);
+                expect(isTypeError).toBe(true);
+            `);
+        });
+    });
+
+    describe('data descriptors stay passthru (the expando capability is preserved)', () => {
+        it('passes a data expando through to the raw target via Object.defineProperty', () => {
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                Object.defineProperty(liveTarget, 'dataExpando', {
+                    configurable: true,
+                    writable: true,
+                    value: 'DATA_VALUE',
+                });
+                // A data descriptor is passthru: the value lands on the raw
+                // target and reads back through the live get.
+                expect(liveTarget.dataExpando).toBe('DATA_VALUE');
+            `);
+
+            // Host observes the expando on the raw target.
+            expect(liveTarget.dataExpando).toBe('DATA_VALUE');
+            const rawDesc = Reflect.getOwnPropertyDescriptor(liveTarget, 'dataExpando');
+            expect(rawDesc && rawDesc.value).toBe('DATA_VALUE');
+        });
+
+        it('passes a function-valued data expando through to the raw target', () => {
+            expect.assertions(2);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                // A function VALUE is still a data descriptor (no get/set key),
+                // so it passes through. Only accessor descriptors are contained.
+                Object.defineProperty(liveTarget, 'fn', {
+                    configurable: true,
+                    writable: true,
+                    value: function tag() {
+                        return 'RED_FN';
+                    },
+                });
+                expect(typeof liveTarget.fn).toBe('function');
+            `);
+
+            expect(typeof liveTarget.fn).toBe('function');
+        });
+
+        it('keeps set, deleteProperty, and indexed writes flowing after an accessor is contained', () => {
+            expect.assertions(6);
+
+            const liveTarget = markLive({ removable: 'gone-soon' });
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                // Contain an accessor, then confirm every other live capability
+                // still reaches the raw shared target.
+                Object.defineProperty(liveTarget, 'acc', {
+                    configurable: true,
+                    get() {
+                        return 'contained';
+                    },
+                });
+                liveTarget.added = 'via-set';
+                delete liveTarget.removable;
+                expect(liveTarget.acc).toBe(undefined);
+                expect(liveTarget.added).toBe('via-set');
+                expect('removable' in liveTarget).toBe(false);
+            `);
+
+            // Host observes the value mutations on the raw target; the accessor
+            // is not present there.
+            expect(liveTarget.added).toBe('via-set');
+            expect('removable' in liveTarget).toBe(false);
+            expect(Reflect.getOwnPropertyDescriptor(liveTarget, 'acc')).toBe(undefined);
+        });
+
+        it('positive control: the same accessor IS observable on a red-native object', () => {
+            // Proves the inertness assertions above are meaningful and not
+            // vacuous. defineProperty of an accessor onto an object the sandbox
+            // itself created (a red-native object) DOES take effect and DOES run
+            // on read. The security property is that the same operation is inert
+            // only when the target is a live host object crossing the membrane.
+            expect.assertions(3);
+
+            const liveTarget = markLive({});
+            const env = createLiveEnvironment({ liveTarget });
+
+            env.evaluate(`
+                let redRan = false;
+                const redObject = {};
+                Object.defineProperty(redObject, 'acc', {
+                    configurable: true,
+                    get() {
+                        redRan = true;
+                        return 'red-native';
+                    },
+                });
+                // On a red-native object the accessor is a normal ordinary
+                // operation: the getter runs and resolves.
+                expect(redObject.acc).toBe('red-native');
+                expect(redRan).toBe(true);
+
+                // On the live host target the identical operation is inert.
+                let liveRan = false;
+                Object.defineProperty(liveTarget, 'acc', {
+                    configurable: true,
+                    get() {
+                        liveRan = true;
+                        return 'live';
+                    },
+                });
+                expect(liveTarget.acc).toBe(undefined);
+            `);
+        });
+    });
+});
+
+describe('defineProperty accessor isolation on structurally-live foreign arrays and typed arrays', () => {
+    it('does not plant an accessor on a foreign array and keeps index access intact', () => {
+        expect.assertions(5);
+
+        const blueArray = [10, 20, 30];
+        const env = createLiveEnvironment({ blueArray });
+
+        env.evaluate(`
+            let ran = false;
+            Object.defineProperty(blueArray, 'pwned', {
+                configurable: true,
+                get() {
+                    ran = true;
+                    return 'leak';
+                },
+            });
+            expect(blueArray.pwned).toBe(undefined);
+            expect(ran).toBe(false);
+            // Liveness intact: indexed writes still reach the backing array.
+            blueArray[0] = 99;
+            expect(blueArray[0]).toBe(99);
+        `);
+
+        expect(blueArray[0]).toBe(99);
+        expect(Reflect.getOwnPropertyDescriptor(blueArray, 'pwned')).toBe(undefined);
+    });
+
+    it('does not plant an accessor on a foreign typed array and keeps index/length intact', () => {
+        expect.assertions(5);
+
+        const blueU8 = new Uint8Array([1, 2, 3, 4]);
+        const env = createLiveEnvironment({ blueU8 });
+
+        env.evaluate(`
+            let ran = false;
+            Object.defineProperty(blueU8, 'pwned', {
+                configurable: true,
+                get() {
+                    ran = true;
+                    return 'leak';
+                },
+            });
+            expect(blueU8.pwned).toBe(undefined);
+            expect(ran).toBe(false);
+            // The typed-array fast path is unaffected: indices and cached length
+            // still resolve against the buffer.
+            expect(blueU8[2]).toBe(3);
+            blueU8[0] = 42;
+            expect(blueU8[0]).toBe(42);
+        `);
+
+        expect(blueU8[0]).toBe(42);
+    });
+});
+
+describe('defineProperty on plain (static) foreign objects is unaffected by the fix', () => {
+    it('keeps a static accessor definition scoped to the shadow target', () => {
+        expect.assertions(3);
+
+        const staticObj = { own: 1 };
+        const env = createVirtualEnvironment(window, {
+            endowments: Object.getOwnPropertyDescriptors({ expect, staticObj }),
+        });
+
+        env.evaluate(`
+            let ran = false;
+            Object.defineProperty(staticObj, 'acc', {
+                configurable: true,
+                get() {
+                    ran = true;
+                    return 'static';
+                },
+            });
+            // For a static proxy the definition lands on the shadow target, so
+            // the sandbox observes its own accessor locally.
+            expect(staticObj.acc).toBe('static');
+            expect(ran).toBe(true);
+        `);
+
+        // The raw host object is untouched: static defineProperty was never
+        // passthru, so this behavior is the pre-existing baseline, not the fix.
+        expect(Reflect.getOwnPropertyDescriptor(staticObj, 'acc')).toBe(undefined);
+    });
+});


### PR DESCRIPTION
A live BoundaryProxyHandler installed the passthru [[DefineOwnProperty]] trap via makeProxyLive(), which forwards the whole descriptor to the RAW foreign target. For an ACCESSOR descriptor that plants a sandbox-authored getter/setter directly onto a host-shared object (a getComputedStyle result, element.style, dataset, Storage, a structurally-live Array/ArrayBufferView, or any @@lockerLiveValue-tagged object such as a LightningElement instance). Because the descriptor's functions are marshalled as pointers back into the sandbox, a later access from the primary realm (a confused deputy reading the planted key) would execute sandbox code with the RAW object as receiver and read raw-global-only state through it.

Route the live defineProperty trap to a new liveAccessorGuardedDefinePropertyTrap: accessor descriptors are scoped to the inert shadow target, while data descriptors stay passthru to the raw target (the expando capability live targets actually need). This mirrors the setPrototypeOf fix (W-23623814): the accessor definition is observably inert from every side. A live get resolves against the RAW foreign target (lookupForeignDescriptor reads the raw own descriptor and walks the RAW prototype chain; it only writes the shadow target, never reads its own properties), so the sandbox reads back undefined for a shadow-scoped accessor too. The security-relevant guarantee is that no sandbox-authored callback ever reaches the raw host-shared object. set, deleteProperty, preventExtensions, and indexed writes are untouched.

Tests: defineProperty accessor isolation on live targets (membrane + DOM realm), covering accessor containment on plain live objects, live arrays, and live typed arrays, the data-expando passthru that must not regress, liveness after an accessor is contained, a confused-deputy host-read probe, and a red-native positive control.