### PR TITLE
fix: @W-23789302 [266][LWS] Marshal variadic trap args with [[DefineOwnProperty]]

### DIFF
--- a/packages/near-membrane-base/src/membrane.ts
+++ b/packages/near-membrane-base/src/membrane.ts
@@ -1368,31 +1368,51 @@ export function createMembraneMarshall(
                 const thisArgOrNewTarget = isApplyTrap ? thisArgOrArgs : argsOrNewTarget;
                 let combinedOffset = 2;
                 const combinedArgs = new ArrayCtor(length + combinedOffset);
-                combinedArgs[0] = foreignTargetPointer;
+                // Use `[[DefineOwnProperty]]` (via `ReflectDefineProperty`) rather than
+                // `[[Set]]` (`combinedArgs[i] = value`) to populate the combined arguments.
+                // A plain array still inherits from `Array.prototype`, so a `[[Set]]` on a
+                // numeric index would invoke an inherited accessor if sandboxed code has
+                // installed one (e.g. `Object.defineProperty(Array.prototype, '2', { set })`).
+                // Such a setter can observe and overwrite the pointers marshalled here —
+                // including `combinedArgs[0]`, the foreign target pointer — redirecting the
+                // call to a different foreign callable. Defining own data properties bypasses
+                // the prototype chain entirely and is immune to prototype pollution.
+                ReflectDefineProperty(combinedArgs, 0, {
+                    __proto__: null,
+                    value: foreignTargetPointer,
+                } as PropertyDescriptor);
                 let pointerOrPrimitive: PointerOrPrimitive;
                 try {
-                    combinedArgs[1] =
-                        (typeof thisArgOrNewTarget === 'object' && thisArgOrNewTarget !== null) ||
-                        typeof thisArgOrNewTarget === 'function'
-                            ? getTransferablePointer(thisArgOrNewTarget)
-                            : // Intentionally ignoring `document.all`.
-                            // https://developer.mozilla.org/en-US/docs/Web/API/Document/all
-                            // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
-                            typeof thisArgOrNewTarget === 'undefined'
-                            ? undefined
-                            : thisArgOrNewTarget;
-                    for (let i = 0; i < length; i += 1) {
-                        const arg = args[i];
-                        // Inlining `getTransferableValue()`.
-                        combinedArgs[combinedOffset++] =
-                            (typeof arg === 'object' && arg !== null) || typeof arg === 'function'
-                                ? getTransferablePointer(arg)
+                    ReflectDefineProperty(combinedArgs, 1, {
+                        __proto__: null,
+                        value:
+                            (typeof thisArgOrNewTarget === 'object' &&
+                                thisArgOrNewTarget !== null) ||
+                            typeof thisArgOrNewTarget === 'function'
+                                ? getTransferablePointer(thisArgOrNewTarget)
                                 : // Intentionally ignoring `document.all`.
                                 // https://developer.mozilla.org/en-US/docs/Web/API/Document/all
                                 // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
-                                typeof arg === 'undefined'
+                                typeof thisArgOrNewTarget === 'undefined'
                                 ? undefined
-                                : arg;
+                                : thisArgOrNewTarget,
+                    } as PropertyDescriptor);
+                    for (let i = 0; i < length; i += 1) {
+                        const arg = args[i];
+                        // Inlining `getTransferableValue()`.
+                        ReflectDefineProperty(combinedArgs, combinedOffset++, {
+                            __proto__: null,
+                            value:
+                                (typeof arg === 'object' && arg !== null) ||
+                                typeof arg === 'function'
+                                    ? getTransferablePointer(arg)
+                                    : // Intentionally ignoring `document.all`.
+                                    // https://developer.mozilla.org/en-US/docs/Web/API/Document/all
+                                    // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
+                                    typeof arg === 'undefined'
+                                    ? undefined
+                                    : arg,
+                        } as PropertyDescriptor);
                     }
                     pointerOrPrimitive = ReflectApply(
                         foreignCallableApplyOrConstruct,
@@ -3764,7 +3784,17 @@ export function createMembraneMarshall(
                     const pointerOrPrimitive = args[i];
                     if (typeof pointerOrPrimitive === 'function') {
                         pointerOrPrimitive();
-                        args[i] = selectedTarget;
+                        // Use `[[DefineOwnProperty]]` rather than `[[Set]]` (`args[i] = ...`).
+                        // `args` is a rest-parameter array that still inherits from
+                        // `Array.prototype`, so a plain assignment to a numeric index would
+                        // invoke an inherited accessor installed by sandboxed code (e.g.
+                        // `Object.defineProperty(Array.prototype, '2', { set })`). Such a
+                        // setter could observe and overwrite the un-marshalled arguments
+                        // before they reach the target function. See W-23789302.
+                        ReflectDefineProperty(args, i, {
+                            __proto__: null,
+                            value: selectedTarget,
+                        } as PropertyDescriptor);
                         selectedTarget = undefined;
                     }
                 }

--- a/test/membrane/security.spec.js
+++ b/test/membrane/security.spec.js
@@ -1,6 +1,135 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 
 describe('Security boundary', () => {
+    // Regression: W-23789302. The variadic apply/construct trap
+    // (createApplyOrConstructTrapForAnyNumberOfArgs) marshals a 6+-argument
+    // cross-boundary call into a combined-args array. If it populated that array
+    // with `[[Set]]` (`combinedArgs[i] = value`) instead of `[[DefineOwnProperty]]`,
+    // sandboxed (red) code could install an inherited numeric setter on
+    // `Array.prototype` that fires mid-marshal and overwrites already-placed slots --
+    // including `combinedArgs[0]`, the foreign target pointer. Because the first user
+    // argument is marshalled into `combinedArgs[2]`, a setter on `Array.prototype['2']`
+    // can copy that argument's pointer over index 0 and redirect the call to a
+    // different blue callable. These tests exercise a REAL cross-realm boundary
+    // (iframe realm via createVirtualEnvironment); the fix must hold end-to-end.
+    describe('inherited Array.prototype setter cannot corrupt marshalled args (W-23789302)', () => {
+        const NUMERIC_SETTER_KEY = '2';
+
+        afterEach(() => {
+            // Defensive: ensure the polluting accessor never leaks between specs even
+            // if a test body throws before its own cleanup runs.
+            delete Array.prototype[NUMERIC_SETTER_KEY];
+        });
+
+        it('does not redirect a 6-arg call to a different blue target', () => {
+            expect.assertions(1);
+
+            // Two distinct blue callables. `intended` is the nominal target; `redirect`
+            // is what the attacker's setter would divert the call to by stomping the
+            // target pointer at combinedArgs[0] with the first user arg's pointer.
+            const intended = (...args) => `intended:${args.length}`;
+            const redirect = () => 'REDIRECTED';
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ intended, redirect }),
+            });
+
+            // Sandboxed code pollutes Array.prototype[2] so that setting index 2 of any
+            // inheriting array overwrites index 0 with the value being set (mirrors the
+            // locker hasFocus PoC), then calls the intended blue target with 6 args --
+            // routing through the variadic trap -- passing `redirect` as the first arg
+            // (which lands at combinedArgs[2]).
+            const result = env.evaluate(`
+                Object.defineProperty(Array.prototype, '${NUMERIC_SETTER_KEY}', {
+                    configurable: true,
+                    set(pointer) {
+                        Object.defineProperty(this, '0', { value: pointer, configurable: true });
+                        Object.defineProperty(this, '2', { value: 'x', configurable: true });
+                    },
+                });
+                try {
+                    intended(redirect, 'b', 'c', 'd', 'e', 'f');
+                } finally {
+                    delete Array.prototype['${NUMERIC_SETTER_KEY}'];
+                }
+            `);
+
+            // With the fix the intended target ran with its six args. Without it the call
+            // is redirected to `redirect` (returns 'REDIRECTED') -- a proven escape vector.
+            expect(result).toBe('intended:6');
+        });
+
+        it('delivers 6 unmangled arguments to the blue target', () => {
+            expect.assertions(1);
+
+            // Report each argument's identity back across the boundary; the setter, if it
+            // fired, would replace index 0's value and stomp index 2.
+            const collect = (...args) =>
+                args.map((a) => (typeof a === 'object' ? a.tag : a)).join(',');
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ collect }),
+            });
+
+            const result = env.evaluate(`
+                const mk = (t) => ({ tag: t });
+                Object.defineProperty(Array.prototype, '${NUMERIC_SETTER_KEY}', {
+                    configurable: true,
+                    set(pointer) {
+                        Object.defineProperty(this, '0', { value: pointer, configurable: true });
+                        Object.defineProperty(this, '2', { value: 'HACKED', configurable: true });
+                    },
+                });
+                try {
+                    collect(mk('a'), mk('b'), mk('c'), mk('d'), mk('e'), mk('f'));
+                } finally {
+                    delete Array.prototype['${NUMERIC_SETTER_KEY}'];
+                }
+            `);
+
+            expect(result).toBe('a,b,c,d,e,f');
+        });
+
+        it('does not redirect a 6-arg construct (new) to a different blue target', () => {
+            expect.assertions(1);
+
+            // The construct trap is built from the SAME variadic factory
+            // (createApplyOrConstructTrapForAnyNumberOfArgs) as the apply trap, so a
+            // `new` call with 6+ args flows through the identical combinedArgs marshalling.
+            // Here combinedArgs[1] carries the newTarget rather than a thisArg, but the
+            // corruption vector is unchanged: the inherited setter still overwrites
+            // combinedArgs[0] (the target pointer), redirecting which constructor runs.
+            function Intended(...args) {
+                this.who = 'intended';
+                this.count = args.length;
+            }
+            function Redirect() {
+                this.who = 'REDIRECTED';
+            }
+            const env = createVirtualEnvironment(window, {
+                endowments: Object.getOwnPropertyDescriptors({ Intended, Redirect }),
+            });
+
+            const result = env.evaluate(`
+                Object.defineProperty(Array.prototype, '${NUMERIC_SETTER_KEY}', {
+                    configurable: true,
+                    set(pointer) {
+                        Object.defineProperty(this, '0', { value: pointer, configurable: true });
+                        Object.defineProperty(this, '2', { value: 'x', configurable: true });
+                    },
+                });
+                try {
+                    const instance = new Intended(Redirect, 'b', 'c', 'd', 'e', 'f');
+                    instance.who + ':' + instance.count;
+                } finally {
+                    delete Array.prototype['${NUMERIC_SETTER_KEY}'];
+                }
+            `);
+
+            // With the fix, the intended constructor ran with its six args. Without it,
+            // the setter diverts construction to `Redirect` (yielding 'REDIRECTED').
+            expect(result).toBe('intended:6');
+        });
+    });
+
     describe('prototype poisoning resistance', () => {
         it('membrane evaluate returns values correctly after Object.keys is replaced post-creation', () => {
             const env = createVirtualEnvironment(window);


### PR DESCRIPTION
The variadic apply/construct trap populated its combined-arguments array with [[Set]] on a plain, Array.prototype-inheriting array. Sandboxed code could install an inherited numeric setter on Array.prototype (e.g. index 2) that fires during marshalling and overwrites combinedArgs[0] (the foreign target pointer), redirecting a 6+-arg cross-boundary call to a different foreign callable (a confirmed sandbox escape, W-23789302).

Use ReflectDefineProperty ([[DefineOwnProperty]]) to populate the marshalled argument arrays on both the send side (createApplyOrConstructTrapForAnyNumberOfArgs) and the receive side (callableApply's ...args). Defining own data properties never consults the prototype chain, so an inherited accessor cannot observe or corrupt the arguments. **Covers all length >= 6 calls, apply and construct. That is, it only impacts function calls with >= 6 arguments** 

Adds discriminating cross-realm karma regression tests (negative-control verified).